### PR TITLE
ci: split CI workflow into separate test and lint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:
@@ -42,28 +42,3 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-  lint:
-    name: Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Check TypeScript
-        run: pnpm exec tsc --noEmit
-
-      - name: Run Biome linter
-        run: pnpm lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+
+jobs:
+  lint:
+    name: Type Check & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check TypeScript
+        run: pnpm exec tsc --noEmit
+
+      - name: Run Biome linter
+        run: pnpm lint


### PR DESCRIPTION
## Summary

Splits the monolithic CI workflow into two separate workflow files for better visibility and parallelization in the GitHub Actions UI.

## Changes

### CI/CD
- **.github/workflows/ci.yml**: Renamed workflow from "CI" to "Test", removed lint job
- **.github/workflows/lint.yml**: New workflow file dedicated to type checking and linting

## Details

**Test Workflow** (ci.yml):
- Renamed from "CI" to "Test" for clarity
- Retains all functional testing jobs:
  - Unit tests with coverage
  - Database initialization (local)
  - Content indexing (local)
  - Production build verification

**Lint Workflow** (lint.yml):
- New dedicated workflow for code quality checks
- Contains:
  - TypeScript type checking (`tsc --noEmit`)
  - Biome linter (`pnpm lint`)

Both workflows:
- Share identical triggers: push to `main`/`dev`, PRs to `main`/`dev`
- Run in parallel automatically
- Appear as separate status checks in GitHub UI

## Benefits

- **Better visibility**: Separate status badges for tests vs linting
- **Faster feedback**: Lint checks can complete independently from slower test suite
- **Clearer failures**: Easy to identify whether a failure is a test failure or code quality issue
- **Improved UX**: GitHub Actions UI shows two distinct workflow runs instead of one combined run

## Test Plan

- [x] Both workflows triggered on this PR
- [x] Test workflow runs all original test/build steps
- [x] Lint workflow runs type check and linter
- [x] No functional changes to CI logic