### PR TITLE
fix(search): validate origins and normalize queries

### DIFF
--- a/src/pages/api/search.json.test.ts
+++ b/src/pages/api/search.json.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../lib/turso', () => ({
 }));
 
 const { search } = await import('@logan/libsql-search');
+const { getTursoClient } = await import('../../lib/turso');
 
 // Helper to create a minimal APIContext for testing
 function createMockContext(request: Request): APIContext {
@@ -82,6 +83,60 @@ describe('Search API Route', () => {
 
       expect(response.status).toBe(400);
       expect(data.error).toBe('Query parameter is required');
+      expect(search).not.toHaveBeenCalled();
+      expect(getTursoClient).not.toHaveBeenCalled();
+    });
+
+    it('should reject a padded one-character query before searching', async () => {
+      const request = new Request('http://localhost/api/search.json', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '  a  ' }),
+      });
+
+      const response = await POST(createMockContext(request));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Query too short');
+      expect(search).not.toHaveBeenCalled();
+      expect(getTursoClient).not.toHaveBeenCalled();
+    });
+
+    it('should reject a whitespace-only query before searching', async () => {
+      const request = new Request('http://localhost/api/search.json', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '   ' }),
+      });
+
+      const response = await POST(createMockContext(request));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('Query too short');
+      expect(search).not.toHaveBeenCalled();
+      expect(getTursoClient).not.toHaveBeenCalled();
+    });
+
+    it('should trim a valid query before searching and responding', async () => {
+      const mockResults: SearchResult[] = [];
+      vi.mocked(search).mockResolvedValueOnce(mockResults);
+
+      const request = new Request('http://localhost/api/search.json', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '  test query  ' }),
+      });
+
+      const response = await POST(createMockContext(request));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.query).toBe('test query');
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'test query' }),
+      );
     });
 
     it('should use default limit of 10 when not provided', async () => {

--- a/src/pages/api/search.json.ts
+++ b/src/pages/api/search.json.ts
@@ -12,6 +12,7 @@ import {
   SEARCH_TABLE_NAME,
 } from '@/lib/searchConfig';
 import { getTursoClient } from '@/lib/turso';
+import { isValidSearchQuery } from '@/lib/validation';
 import { checkRateLimit, createRateLimitHeaders } from '@/middleware/rateLimit';
 
 export const prerender = false;
@@ -46,8 +47,17 @@ export function validateOrigin(
   const origin = request.headers.get('origin');
   const referer = request.headers.get('referer');
 
-  // If no origin header, check referer (some browsers don't send origin on same-origin)
-  const requestOrigin = origin || (referer ? new URL(referer).origin : null);
+  // If no origin header, check referer (some browsers don't send origin on
+  // same-origin requests). Treat malformed headers as invalid instead of
+  // allowing URL parsing errors to escape the request handler.
+  let requestOrigin = origin;
+  if (!requestOrigin && referer) {
+    try {
+      requestOrigin = new URL(referer).origin;
+    } catch {
+      return false;
+    }
+  }
 
   // No origin/referer could be a same-origin request or a non-browser client
   // For API security, we should require origin for POST requests
@@ -60,8 +70,11 @@ export function validateOrigin(
     return false;
   }
 
-  // Check if origin matches the site URL
-  if (siteUrl && requestOrigin === siteUrl.origin) {
+  // Prefer the configured canonical site, but fall back to the actual request
+  // origin so deployments without Astro.site can still validate same-origin
+  // browser requests.
+  const expectedOrigin = siteUrl?.origin ?? new URL(request.url).origin;
+  if (requestOrigin === expectedOrigin) {
     return true;
   }
 
@@ -161,15 +174,27 @@ export const POST: APIRoute = async ({ request, site }) => {
   try {
     const { query, limit = 10 } = body;
 
-    if (!query || typeof query !== 'string') {
+    if (typeof query !== 'string') {
       return new Response(
         JSON.stringify({ error: 'Query parameter is required' }),
         { status: 400, headers: rateLimitHeaders },
       );
     }
 
+    if (!isValidSearchQuery(query)) {
+      return new Response(
+        JSON.stringify({
+          error: 'Query too short',
+          message: 'Query must contain at least 2 non-whitespace characters',
+        }),
+        { status: 400, headers: rateLimitHeaders },
+      );
+    }
+
+    const normalizedQuery = query.trim();
+
     // Limit query length to prevent abuse
-    if (query.length > 500) {
+    if (normalizedQuery.length > 500) {
       return new Response(
         JSON.stringify({
           error: 'Query too long',
@@ -196,7 +221,7 @@ export const POST: APIRoute = async ({ request, site }) => {
     // Perform vector search using centralized env config
     const results = await search({
       client,
-      query,
+      query: normalizedQuery,
       limit: sanitizedLimit,
       tableName: SEARCH_TABLE_NAME,
       embeddingOptions: {
@@ -209,7 +234,7 @@ export const POST: APIRoute = async ({ request, site }) => {
       JSON.stringify({
         results,
         count: results.length,
-        query,
+        query: normalizedQuery,
       }),
       {
         status: 200,

--- a/src/pages/api/search.test.ts
+++ b/src/pages/api/search.test.ts
@@ -21,8 +21,11 @@ const testEnv: ValidateOriginEnv = {
 };
 
 // Helper to create a mock Request with specified headers
-function createRequest(headers: Record<string, string> = {}): Request {
-  return new Request('http://localhost/api/search.json', {
+function createRequest(
+  headers: Record<string, string> = {},
+  url = 'http://localhost/api/search.json',
+): Request {
+  return new Request(url, {
     method: 'POST',
     headers,
   });
@@ -290,10 +293,34 @@ describe('validateOrigin', () => {
   });
 
   describe('null/undefined siteUrl', () => {
-    it('should handle undefined siteUrl gracefully in production', () => {
-      const request = createRequest({ origin: 'https://example.com' });
+    it('should use the request URL for same-origin validation in production', () => {
+      const request = createRequest(
+        { origin: 'https://example.com' },
+        'https://example.com/api/search.json',
+      );
 
-      // siteUrl is undefined, so origin can't match - falls through to return false
+      const result = validateOrigin(request, undefined, productionEnv);
+
+      expect(result).toBe(true);
+    });
+
+    it('should use the request URL for same-origin referer validation', () => {
+      const request = createRequest(
+        { referer: 'https://example.com/docs/getting-started' },
+        'https://example.com/api/search.json',
+      );
+
+      const result = validateOrigin(request, undefined, productionEnv);
+
+      expect(result).toBe(true);
+    });
+
+    it('should reject a cross-origin request when siteUrl is undefined', () => {
+      const request = createRequest(
+        { origin: 'https://malicious.com' },
+        'https://example.com/api/search.json',
+      );
+
       const result = validateOrigin(request, undefined, productionEnv);
 
       expect(result).toBe(false);
@@ -381,16 +408,15 @@ describe('validateOrigin', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle malformed referer URL by throwing', () => {
-      // Create a request with a malformed referer
-      // The URL constructor in the function will throw on invalid URLs
+    it('should reject a malformed referer URL', () => {
       const request = createRequest({
         referer: 'not-a-valid-url',
       });
       const siteUrl = createSiteUrl('https://example.com');
 
-      // The URL constructor throws on invalid URLs
-      expect(() => validateOrigin(request, siteUrl, productionEnv)).toThrow();
+      const result = validateOrigin(request, siteUrl, productionEnv);
+
+      expect(result).toBe(false);
     });
 
     it('should handle origin with trailing slash correctly', () => {


### PR DESCRIPTION
Closes #73

## Summary
- Use `Astro.site` for production same-origin validation when configured, and fall back to the request URL origin otherwise.
- Reject malformed or cross-origin search requests and normalize queries through the shared minimum-length validation path before search/database work.
- Add tests covering origin validation, malformed requests, trimmed query handling, and rejected short or whitespace-only queries.

## Validation
- pnpm format
- pnpm lint
- pnpm exec tsc --noEmit
- pnpm test --run (158 tests)
- pnpm db:init:local
- pnpm index:local (3/3 docs)
- env TURSO_DB_URL=file:local.db TURSO_AUTH_TOKEN=local pnpm build
