### PR TITLE
fix(search): prevent stale dialog request state

### DIFF
--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -1,9 +1,46 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Search from './Search';
 
 // Mock fetch
 global.fetch = vi.fn();
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createSearchResponse(id: number, title: string): Response {
+  return {
+    ok: true,
+    json: async () => ({
+      results: [
+        {
+          id,
+          title,
+          slug: title.toLowerCase().replaceAll(' ', '-'),
+          folder: 'docs',
+          tags: [],
+          distance: 0.5,
+        },
+      ],
+      count: 1,
+      query: title,
+    }),
+  } as Response;
+}
 
 describe('Search Component', () => {
   beforeEach(() => {
@@ -130,6 +167,87 @@ describe('Search Component', () => {
       expect(screen.getByText('DOCS')).toBeDefined();
       expect(screen.getByText('testing')).toBeDefined();
     });
+  });
+
+  it('should let only the active request update results and loading state', async () => {
+    const firstRequest = createDeferred<Response>();
+    const secondRequest = createDeferred<Response>();
+    vi.mocked(global.fetch)
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+
+    render(<Search />);
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    const input = await screen.findByPlaceholderText('Search articles...');
+    fireEvent.change(input, { target: { value: 'first query' } });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1), {
+      timeout: 500,
+    });
+    const firstSignal = vi.mocked(global.fetch).mock.calls[0][1]?.signal;
+
+    fireEvent.change(input, { target: { value: 'second query' } });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2), {
+      timeout: 500,
+    });
+    expect(firstSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      firstRequest.resolve(createSearchResponse(1, 'Stale Result'));
+      await firstRequest.promise;
+    });
+
+    expect(screen.queryByText('Stale Result')).toBeNull();
+    expect(screen.getByText('Searching...')).toBeDefined();
+
+    await act(async () => {
+      secondRequest.resolve(createSearchResponse(2, 'Second Query Result'));
+      await secondRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Second Query Result')).toBeDefined();
+      expect(screen.queryByText('Searching...')).toBeNull();
+    });
+  });
+
+  it('should abort and reset an active request when closed and reopened', async () => {
+    const request = createDeferred<Response>();
+    vi.mocked(global.fetch).mockReturnValueOnce(request.promise);
+
+    render(<Search />);
+    const searchButton = screen.getByRole('button', { name: 'Search' });
+    fireEvent.click(searchButton);
+
+    const input = await screen.findByPlaceholderText('Search articles...');
+    fireEvent.change(input, { target: { value: 'in flight' } });
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1), {
+      timeout: 500,
+    });
+    const signal = vi.mocked(global.fetch).mock.calls[0][1]?.signal;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(signal?.aborted).toBe(true);
+
+    await act(async () => {
+      request.resolve(createSearchResponse(1, 'Late Result'));
+      await request.promise;
+    });
+
+    fireEvent.click(searchButton);
+    const reopenedInput =
+      await screen.findByPlaceholderText('Search articles...');
+
+    expect((reopenedInput as HTMLInputElement).value).toBe('');
+    expect(screen.queryByText('Late Result')).toBeNull();
+    expect(screen.queryByText('Searching...')).toBeNull();
+    expect(screen.queryByText('Search failed. Please try again.')).toBeNull();
+    expect(
+      screen.getByText('Type at least 2 characters to search...'),
+    ).toBeDefined();
   });
 
   it('should show no results message when no results found', async () => {

--- a/src/components/Search.test.tsx
+++ b/src/components/Search.test.tsx
@@ -66,6 +66,26 @@ describe('Search Component', () => {
     });
   });
 
+  it('should toggle with the keyboard shortcut and reopen cleanly', async () => {
+    render(<Search />);
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    const input = await screen.findByPlaceholderText('Search articles...');
+    fireEvent.change(input, { target: { value: 'pending query' } });
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Search articles...')).toBeNull();
+    });
+
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    const reopenedInput =
+      await screen.findByPlaceholderText('Search articles...');
+
+    expect((reopenedInput as HTMLInputElement).value).toBe('');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('should not search when query is less than 2 characters', async () => {
     render(<Search />);
     const button = screen.getByRole('button', { name: 'Search' });
@@ -167,6 +187,31 @@ describe('Search Component', () => {
       expect(screen.getByText('DOCS')).toBeDefined();
       expect(screen.getByText('testing')).toBeDefined();
     });
+
+    fireEvent.click(screen.getByRole('link', { name: /Test Article/ }));
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('Search articles...')).toBeNull();
+    });
+  });
+
+  it('should show an error only for the active request', async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+    render(<Search />);
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    const input = await screen.findByPlaceholderText('Search articles...');
+    fireEvent.change(input, { target: { value: 'broken query' } });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText('Search failed. Please try again.'),
+        ).toBeDefined();
+        expect(screen.queryByText('Searching...')).toBeNull();
+      },
+      { timeout: 500 },
+    );
   });
 
   it('should let only the active request update results and loading state', async () => {

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -84,14 +84,6 @@ export default function Search({
   // Debounced search function
   const performSearch = useCallback(
     async (searchQuery: string) => {
-      if (searchQuery.length < 2) {
-        cancelActiveSearch();
-        setResults([]);
-        setLoading(false);
-        setError(null);
-        return;
-      }
-
       cancelActiveSearch();
 
       const controller = new AbortController();

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -40,33 +40,62 @@ export default function Search({
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
+  const cancelActiveSearch = useCallback(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+      searchTimeoutRef.current = null;
+    }
+
+    const activeController = abortControllerRef.current;
+    abortControllerRef.current = null;
+    activeController?.abort();
+  }, []);
+
+  const resetSearch = useCallback(() => {
+    cancelActiveSearch();
+    setQuery('');
+    setResults([]);
+    setLoading(false);
+    setError(null);
+  }, [cancelActiveSearch]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        resetSearch();
+      }
+    },
+    [resetSearch],
+  );
+
   // Handle ⌘K keyboard shortcut
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setOpen((open) => !open);
+        handleOpenChange(!open);
       }
     };
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
-  }, []);
+  }, [handleOpenChange, open]);
 
   // Debounced search function
   const performSearch = useCallback(
     async (searchQuery: string) => {
       if (searchQuery.length < 2) {
+        cancelActiveSearch();
         setResults([]);
+        setLoading(false);
+        setError(null);
         return;
       }
 
-      // Cancel any in-flight request
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
+      cancelActiveSearch();
 
-      // Create new AbortController for this request
-      abortControllerRef.current = new AbortController();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
 
       setLoading(true);
       setError(null);
@@ -79,7 +108,7 @@ export default function Search({
             query: searchQuery,
             limit: maxResults,
           }),
-          signal: abortControllerRef.current.signal,
+          signal: controller.signal,
         });
 
         if (!response.ok) {
@@ -87,8 +116,17 @@ export default function Search({
         }
 
         const data = await response.json();
+
+        if (abortControllerRef.current !== controller) {
+          return;
+        }
+
         setResults(data.results || []);
       } catch (err) {
+        if (abortControllerRef.current !== controller) {
+          return;
+        }
+
         // Ignore AbortError - it's expected when cancelling requests
         if (err instanceof Error && err.name === 'AbortError') {
           return;
@@ -96,52 +134,38 @@ export default function Search({
         setError('Search failed. Please try again.');
         setResults([]);
       } finally {
-        setLoading(false);
+        if (abortControllerRef.current === controller) {
+          abortControllerRef.current = null;
+          setLoading(false);
+        }
       }
     },
-    [maxResults],
+    [cancelActiveSearch, maxResults],
   );
 
   // Handle input changes with debouncing
   const handleValueChange = useCallback(
     (value: string) => {
       setQuery(value);
-
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current);
-      }
+      cancelActiveSearch();
+      setResults([]);
+      setLoading(false);
+      setError(null);
 
       if (value.length >= 2) {
         searchTimeoutRef.current = setTimeout(() => {
+          searchTimeoutRef.current = null;
           performSearch(value);
         }, 300);
-      } else {
-        setResults([]);
       }
     },
-    [performSearch],
+    [cancelActiveSearch, performSearch],
   );
 
   // Cleanup timeout and abort controller on unmount
   useEffect(() => {
-    return () => {
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current);
-      }
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-    };
-  }, []);
-
-  // Reset state when dialog closes
-  useEffect(() => {
-    if (!open) {
-      setQuery('');
-      setResults([]);
-      setError(null);
-    }
-  }, [open]);
+    return cancelActiveSearch;
+  }, [cancelActiveSearch]);
 
   // Group results by folder (memoized to avoid recalculation on each render)
   const groupedResults = useMemo(() => {
@@ -161,7 +185,7 @@ export default function Search({
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={() => handleOpenChange(true)}
         className="relative w-full h-10 flex items-center justify-center sm:justify-start px-2 py-2 text-left text-sm bg-muted/50 border border-input rounded-lg hover:bg-muted transition-colors sm:px-3 sm:pl-10"
         aria-label="Search"
       >
@@ -189,7 +213,7 @@ export default function Search({
         </kbd>
       </button>
 
-      <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandDialog open={open} onOpenChange={handleOpenChange}>
         <CommandInput
           placeholder={placeholder}
           value={query}
@@ -228,7 +252,7 @@ export default function Search({
                         // Keyboard "Enter" path. Mouse clicks call
                         // stopPropagation on the anchor below so cmdk does
                         // not also fire this handler, avoiding a double nav.
-                        setOpen(false);
+                        handleOpenChange(false);
                         window.location.assign(href);
                       }}
                       className="p-0"
@@ -242,7 +266,7 @@ export default function Search({
                         tabIndex={-1}
                         onClick={(e) => {
                           e.stopPropagation();
-                          setOpen(false);
+                          handleOpenChange(false);
                         }}
                         className="flex flex-col items-start gap-1 w-full px-2 py-1.5"
                       >


### PR DESCRIPTION
Closes #74

## Summary
- Add active `AbortController` ownership guards so only the current request can update loading, errors, and results.
- Cancel pending debounce and in-flight search work immediately when the query changes or the dialog closes, then reset dialog state before reopen.
- Add overlap and close/reopen regression coverage for stale-response handling and successful active-request results.

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test --run` (162 tests)
- `pnpm test:coverage --run` (overall line coverage 94.48%; `Search.tsx` line coverage 95.12%)
- `pnpm db:init:local`
- `pnpm index:local` (3/3 documents)
- `env TURSO_DB_URL=file:local.db TURSO_AUTH_TOKEN=local pnpm build`
