### PR TITLE
fix(indexing): fail incomplete content indexing

### DIFF
--- a/scripts/index-content-runner.test.ts
+++ b/scripts/index-content-runner.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type IndexingLogger,
+  type IndexingOperations,
+  runContentIndexing,
+} from './index-content-runner';
+
+function createLogger(): IndexingLogger {
+  return {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe('runContentIndexing', () => {
+  it('returns zero and preserves progress reporting on complete success', async () => {
+    const logger = createLogger();
+    const operations: IndexingOperations = {
+      createTable: vi.fn().mockResolvedValue(undefined),
+      indexContent: vi.fn(async (onProgress) => {
+        onProgress(1, 2, 'getting-started/welcome.md');
+        onProgress(2, 2, 'theme/overview.md');
+        return { success: 2, total: 2, failed: 0 };
+      }),
+    };
+
+    const exitCode = await runContentIndexing(operations, logger);
+
+    expect(exitCode).toBe(0);
+    expect(logger.info).toHaveBeenCalledWith(
+      '[1/2] Indexing: getting-started/welcome.md',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[2/2] Indexing: theme/overview.md',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'Successfully indexed 2/2 documents',
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns nonzero after logging a partial-failure summary', async () => {
+    const logger = createLogger();
+    const operations: IndexingOperations = {
+      createTable: vi.fn().mockResolvedValue(undefined),
+      indexContent: vi
+        .fn()
+        .mockResolvedValue({ success: 2, total: 3, failed: 1 }),
+    };
+
+    const exitCode = await runContentIndexing(operations, logger);
+
+    expect(exitCode).toBe(1);
+    expect(logger.info).toHaveBeenCalledWith('Indexing complete!');
+    expect(logger.info).toHaveBeenCalledWith(
+      'Successfully indexed 2/3 documents',
+    );
+    expect(logger.warn).toHaveBeenCalledWith('Failed to index 1 documents');
+  });
+
+  it('returns nonzero and logs thrown indexing errors', async () => {
+    const logger = createLogger();
+    const indexingError = new Error('embedding failed');
+    const operations: IndexingOperations = {
+      createTable: vi.fn().mockResolvedValue(undefined),
+      indexContent: vi.fn().mockRejectedValue(indexingError),
+    };
+
+    const exitCode = await runContentIndexing(operations, logger);
+
+    expect(exitCode).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Content indexing failed before completion',
+      indexingError,
+    );
+  });
+});

--- a/scripts/index-content-runner.ts
+++ b/scripts/index-content-runner.ts
@@ -1,0 +1,55 @@
+export interface IndexingResult {
+  success: number;
+  total: number;
+  failed: number;
+}
+
+export type IndexProgress = (
+  current: number,
+  total: number,
+  file: string,
+) => void;
+
+export interface IndexingOperations {
+  createTable: () => Promise<unknown>;
+  indexContent: (onProgress: IndexProgress) => Promise<IndexingResult>;
+}
+
+export interface IndexingLogger {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string, error?: unknown) => void;
+}
+
+/**
+ * Run content indexing and return the process exit code the CLI should use.
+ */
+export async function runContentIndexing(
+  operations: IndexingOperations,
+  logger: IndexingLogger,
+): Promise<0 | 1> {
+  logger.info('Starting content indexing...');
+
+  try {
+    await operations.createTable();
+
+    const result = await operations.indexContent((current, total, file) => {
+      logger.info(`[${current}/${total}] Indexing: ${file}`);
+    });
+
+    logger.info('Indexing complete!');
+    logger.info(
+      `Successfully indexed ${result.success}/${result.total} documents`,
+    );
+
+    if (result.failed > 0) {
+      logger.warn(`Failed to index ${result.failed} documents`);
+      return 1;
+    }
+
+    return 0;
+  } catch (error) {
+    logger.error('Content indexing failed before completion', error);
+    return 1;
+  }
+}

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -11,6 +11,7 @@ import {
   LOCAL_EMBEDDING_DIMENSIONS,
   SEARCH_TABLE_NAME,
 } from '../src/lib/searchConfig';
+import { runContentIndexing } from './index-content-runner';
 
 // Initialize client (Turso or local libSQL)
 const url = process.env.TURSO_DB_URL;
@@ -25,28 +26,21 @@ if (!url || !authToken) {
   logger.info('Using local libSQL database (file:local.db)');
 }
 
-logger.info('Starting content indexing...');
-
-// Create table if it doesn't exist
-await createTable(client, SEARCH_TABLE_NAME, LOCAL_EMBEDDING_DIMENSIONS);
-
-// Index content
-const result = await indexContent({
-  client,
-  contentPath: './content',
-  tableName: SEARCH_TABLE_NAME,
-  embeddingOptions: {
-    provider: 'local',
-    dimensions: LOCAL_EMBEDDING_DIMENSIONS,
+process.exitCode = await runContentIndexing(
+  {
+    createTable: () =>
+      createTable(client, SEARCH_TABLE_NAME, LOCAL_EMBEDDING_DIMENSIONS),
+    indexContent: (onProgress) =>
+      indexContent({
+        client,
+        contentPath: './content',
+        tableName: SEARCH_TABLE_NAME,
+        embeddingOptions: {
+          provider: 'local',
+          dimensions: LOCAL_EMBEDDING_DIMENSIONS,
+        },
+        onProgress,
+      }),
   },
-  onProgress: (current, total, file) => {
-    logger.info(`[${current}/${total}] Indexing: ${file}`);
-  },
-});
-
-logger.info(`Indexing complete!`);
-logger.info(`Successfully indexed ${result.success}/${result.total} documents`);
-
-if (result.failed > 0) {
-  logger.warn(`Failed to index ${result.failed} documents`);
-}
+  logger,
+);


### PR DESCRIPTION
Closes #75

## Summary
- Extract testable indexing orchestration out of the CLI entrypoint.
- Return exit code `0` only when indexing completes without failures.
- Keep progress logging and the final indexing summary intact while making partial and thrown failures stop downstream build work.

## Changes

### Indexing
- **scripts/index-content-runner.ts**: Adds a focused indexing runner that returns `0` for full success and `1` for partial results or thrown indexing errors.
- **scripts/index-content.ts**: Uses the runner and assigns `process.exitCode` so CI's existing index-before-build ordering stops before build when indexing is incomplete.

### Tests
- **scripts/index-content-runner.test.ts**: Covers successful indexing, partial failures, and thrown indexing errors while preserving progress and summary logging.

## Validation
- `pnpm format`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test:coverage --run` (165 tests; 94.48% overall line coverage)
- `pnpm db:init:local`
- `pnpm index:local` (3/3 documents)
- `env TURSO_DB_URL=file:local.db TURSO_AUTH_TOKEN=local pnpm build`
