### PR TITLE
docs: refresh project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,324 +2,75 @@
 
 [![Coverage](https://img.shields.io/codecov/c/github/llbbl/semantic-docs?label=coverage)](https://codecov.io/gh/llbbl/semantic-docs) [![CI](https://github.com/llbbl/semantic-docs/actions/workflows/ci.yml/badge.svg)](https://github.com/llbbl/semantic-docs/actions/workflows/ci.yml) [![Release](https://img.shields.io/github/v/release/llbbl/semantic-docs)](https://github.com/llbbl/semantic-docs/releases)
 
-Documentation theme with semantic vector search.
+`semantic-docs` is an Astro documentation theme with built-in semantic search powered by [`@logan/libsql-search`](https://github.com/llbbl/libsql-search). It gives you static docs pages, a server-rendered search API, and a libSQL/Turso-backed content index without adding a separate hosted search product.
 
-A beautiful, dark-mode documentation theme powered by [libsql-search](https://github.com/llbbl/libsql-search) for semantic search capabilities. Perfect for technical documentation, knowledge bases, and content-heavy sites.
+Use it when you want:
 
-## Features
+- semantic search over Markdown content with a small operational footprint
+- a docs site you can ship quickly without giving up control of layout, content, or deployment
+- a lightweight alternative to bolting on a hosted search product
 
-- 🎨 **Modern Dark UI** - Sleek design with OKLCH colors
-- 🔍 **Semantic Search** - AI-powered vector search in the header
-- 📱 **Responsive** - Mobile-friendly with collapsible sidebar
-- 📑 **Auto TOC** - Table of contents generated from headings
-- 🚀 **Edge-Ready** - Optimized for Turso's global database
-- ⚡ **Fast** - Static generation with server-rendered search
-- 🎯 **Type-Safe** - Full TypeScript support
+## What You Get
+
+- Semantic search in the header, backed by libSQL/Turso
+- Static article pages with a server-rendered search endpoint
+- Sidebar navigation and table of contents generated from your content
+- A local development path that works without Turso credentials
 
 ## Quick Start
 
-Requires Node.js 22.13.0 or newer and pnpm 11.
-
-### 1. Clone or Use as Template
+Requires Node.js `>=22.13.0` and pnpm `11`.
 
 ```bash
 git clone https://github.com/llbbl/semantic-docs.git
 cd semantic-docs
-```
-
-Or use as a template on GitHub.
-
-### 2. Install Dependencies
-
-```bash
 pnpm install
-```
-
-Optional: use the `justfile` task runner for common commands:
-
-```bash
-just
-just dev
-just test
-```
-
-See `docs/just.md` for the full list of recipes.
-
-### 3. Set Up Environment
-
-Copy `.env.example` to `.env` and add your credentials:
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env`:
-
-```env
-TURSO_DB_URL=libsql://your-database.turso.io
-TURSO_AUTH_TOKEN=your-auth-token
-```
-
-**Get Turso credentials:**
-
-```bash
-# Install Turso CLI
-curl -sSfL https://get.tur.so/install.sh | bash
-
-# Sign up and authenticate
-turso auth signup
-
-# Create a database
-turso db create my-docs
-
-# Get credentials
-turso db show my-docs
-```
-
-### 4. Add Your Content
-
-Create markdown files in `./content`:
-
-```bash
-mkdir -p content/getting-started
-echo "# Hello World\n\nThis is my first article." > content/getting-started/intro.md
-```
-
-**Front matter support:**
-
-```markdown
----
-title: Getting Started
-tags: [tutorial, beginner]
----
-
-# Getting Started
-
-Your content here...
-```
-
-### 5. Index Content
-
-```bash
-# Initialize database and index content to Turso
-pnpm db:init
-pnpm index
-
-# Or use local database without Turso (for testing)
 pnpm db:init:local
 pnpm index:local
-```
-
-This will:
-- Scan your markdown files
-- Generate embeddings (using libsql-search's local provider by default)
-- Store everything in Turso (or local.db with `:local` commands)
-
-### 6. Start Development
-
-```bash
 pnpm dev
 ```
 
-Visit `http://localhost:4321` to see your docs!
+Open `http://localhost:4321`.
 
-## Customization
+The local path works without Turso credentials. The current repo defaults to the
+`articles_local_384` index with libsql-search configured as `provider: 'local'`
+at 384 dimensions. When you want a remote libSQL/Turso database, switch to the
+`.env`-driven commands in the docs.
 
-### Change Site Title
+## Documentation
 
-Edit `src/components/DocsHeader.astro`:
+- [Docs index](./docs/README.md)
+- [Setup and indexing](./docs/GETTING_STARTED.md)
+- [Deployment notes](./docs/DEPLOYMENT.md)
+- [Project reference](./docs/REFERENCE.md)
+- [Security considerations](./docs/SECURITY.md)
+- [Just task runner](./docs/just.md)
 
-```astro
-<span class="font-sans">Your Site Name</span>
-```
+## Content Shape
 
-And `src/layouts/DocsLayout.astro`:
+Store Markdown under `./content` using folder-based sections:
 
-```astro
-const { title = "Your Site Name", description = "Your description" } = Astro.props;
-```
-
-### Customize Colors
-
-Edit `src/styles/global.css` to change the color scheme. The theme uses OKLCH colors for smooth gradients and perceptual uniformity.
-
-### Embeddings
-
-Semantic search uses libsql-search's local embedding provider by default, so no API keys are required in the default setup.
-
-The local provider uses native 384-dimension vectors stored in the
-`articles_local_384` table. Deployments upgrading from the legacy 768-dimension
-index must run `pnpm db:init` and `pnpm index` before building. The old
-`articles` table is left intact for rollback and can be retired separately after
-the new index is verified.
-
-## Project Structure
-
-```
-semantic-docs/
-├── src/
-│   ├── components/
-│   │   ├── DocsHeader.astro    # Header with search
-│   │   ├── DocsSidebar.astro   # Navigation sidebar
-│   │   ├── DocsToc.tsx         # Table of contents
-│   │   └── Search.tsx          # Search component
-│   ├── layouts/
-│   │   └── DocsLayout.astro    # Main layout
-│   ├── lib/
-│   │   └── turso.ts            # Database client
-│   ├── pages/
-│   │   ├── api/
-│   │   │   └── search.json.ts  # Search API endpoint
-│   │   ├── content/
-│   │   │   └── [...slug].astro # Article pages
-│   │   └── index.astro         # Home page
-│   └── styles/
-│       └── global.css          # Global styles
-├── scripts/
-│   └── index-content.js        # Indexing script
-├── content/                    # Your markdown files
-├── astro.config.mjs
-├── package.json
-└── .env                        # Your credentials
-```
-
-## Deployment
-
-### Container-Based Platforms (Recommended)
-
-This project is designed to run on platforms that support Docker containers, such as:
-
-- [Railway](https://railway.app)
-- [Render](https://render.com)
-- [Fly.io](https://fly.io)
-- Google Cloud Run
-- AWS ECS/Fargate
-- Azure Container Apps
-- Coolify
-
-```bash
-# Build with Node.js adapter (default)
-pnpm build
-
-# The built application runs on Node.js and can be containerized
-# Set environment variables in your platform's dashboard
-```
-
-**Important:** Always run `pnpm index` before deploying to ensure content is indexed.
-
-### Vercel / Netlify
-
-> **Note**: These platforms have not been tested and cannot be recommended at this time.
-
-```bash
-# Build with Node.js adapter (default)
-pnpm build
-
-# Deploy
-vercel
-# or
-netlify deploy --prod
-
-# Add environment variables in platform dashboard
-```
-
-## Content Organization
-
-The theme automatically organizes content by folder:
-
-```
+```text
 content/
 ├── getting-started/
-│   ├── intro.md
-│   └── installation.md
+│   └── intro.md
 ├── guides/
-│   ├── configuration.md
 │   └── deployment.md
 └── reference/
     └── api.md
 ```
 
-Folders become collapsible sections in the sidebar.
+Folders become sidebar groups, and frontmatter can define titles and tags.
 
-## Search
-
-The search bar in the header provides semantic search:
-
-- **Semantic matching**: Finds content by meaning, not just keywords
-- **Instant results**: Real-time as you type
-- **Smart ranking**: Most relevant results first
-- **Tag display**: Shows article tags in results
-
-Try searching for concepts rather than exact phrases!
-
-## Build for Production
+## Development Checks
 
 ```bash
-# Index content
-pnpm index
-
-# Build site
-pnpm build
-
-# Preview
-pnpm preview
+pnpm format
+pnpm lint
+pnpm exec tsc --noEmit
+pnpm test
 ```
-
-## Troubleshooting
-
-### Search not working
-
-1. Check `.env` file has correct credentials
-2. Ensure `output: 'server'` in `astro.config.mjs`
-3. Verify content is indexed: run `pnpm index`
-
-### Content not showing
-
-1. Run `pnpm index` to index your markdown files
-2. Check content is in `./content` directory
-3. Verify Turso database has data
-
-### Local embedding provider slow
-
-The first run may need to download model assets. Subsequent runs use the local cache.
-
-## Tech Stack
-
-- **Framework**: [Astro](https://astro.build) 5
-- **Search**: [libsql-search](https://github.com/llbbl/libsql-search)
-- **Database**: [Turso](https://turso.tech) (libSQL)
-- **Styling**: [Tailwind CSS](https://tailwindcss.com) 4
-- **UI**: React islands for interactivity
-- **Embeddings**: libsql-search local provider
-
-## Releases
-
-Releases are automated via GitHub Actions on every push to `main`. The version bump is determined by [conventional commit](https://www.conventionalcommits.org/) prefixes:
-
-| Commit Prefix | Version Bump | Example |
-|---|---|---|
-| `feat!:` or `BREAKING CHANGE` | **Major** (v2.0.0) | `feat!: redesign search API` |
-| `feat:` | **Minor** (v1.5.0) | `feat(deps): update 19 dependencies` |
-| `fix:`, `chore:`, `docs:`, etc. | **Patch** (v1.4.1) | `fix: handle empty search query` |
-
-The workflow automatically:
-1. Determines the next version from commit messages since the last tag
-2. Updates `package.json` version
-3. Runs type checking and tests
-4. Creates a version commit and git tag
-5. Generates a changelog with [git-cliff](https://git-cliff.org/) and publishes a GitHub Release
-
-To trigger a **minor** release for dependency updates, use `feat(deps):` instead of `chore(deps):` as the commit prefix.
 
 ## License
 
 MIT
-
-## Support
-
-- [Issues](https://github.com/llbbl/semantic-docs/issues)
-- [Discussions](https://github.com/llbbl/semantic-docs/discussions)
-
-## Credits
-
-Built with [libsql-search](https://github.com/llbbl/libsql-search).

--- a/content/features/semantic-search.md
+++ b/content/features/semantic-search.md
@@ -93,11 +93,12 @@ const results = await db.execute(`
 
 ## Embedding Generation
 
-### libsql-search Local Provider
+### Repo Default
 
-semantic-docs delegates embedding generation to libsql-search. The default local
-provider runs without an API key, while keeping the provider implementation out
-of the application code:
+semantic-docs delegates embedding generation to libsql-search. The current repo
+configuration uses `provider: 'local'` with 384-dimension vectors, while
+keeping the provider implementation out of the application code. The repo
+depends on that contract, not on a specific underlying embedding engine:
 
 ```typescript
 import { generateEmbedding } from '@logan/libsql-search';
@@ -113,8 +114,13 @@ console.log(embedding); // [0.123, -0.456, 0.789, ...]
 ## Implementation in semantic-docs
 
 ### Indexing Content
+
+Simplified example of the indexing flow. The real implementation also uses
+shared constants from `src/lib/searchConfig.ts` and routes the work through
+`runContentIndexing`:
+
 ```typescript
-// scripts/index-content.ts
+// Simplified example
 import { createTable, indexContent } from '@logan/libsql-search';
 import { getTursoClient } from '../src/lib/turso';
 
@@ -133,8 +139,13 @@ await indexContent({
 ```
 
 ### Searching
+
+Simplified example of the semantic search call. The real
+`src/pages/api/search.json.ts` also validates input, applies rate limiting,
+uses centralized constants, and returns the current API response shape:
+
 ```typescript
-// src/pages/api/search.json.ts
+// Simplified example
 import { search } from '@logan/libsql-search';
 import { getTursoClient } from '../../lib/turso';
 
@@ -257,7 +268,8 @@ const results = await search({
 Full-text search:  10ms
 Semantic search:   50-100ms
 
-Reason: Vector distance calculations are expensive
+Reason: Vector distance calculations and embedding generation are more
+expensive than keyword-only matching
 ```
 
 ### 2. Requires Vector Index
@@ -271,13 +283,13 @@ CREATE INDEX idx_embedding ON articles(libsql_vector_idx(embedding));
 
 ### 3. Cold Start Problem
 ```javascript
-// First query in session
+// First query in a fresh process or cache
 const embedding = await generateEmbedding(query);
-// Takes 200-500ms to initialize model
+// Often slower while the configured provider warms up
 
 // Subsequent queries
 const embedding2 = await generateEmbedding(query2);
-// Takes 20-50ms (model cached)
+// Usually faster once provider resources are ready
 ```
 
 ### 4. Context Window Limits
@@ -337,10 +349,10 @@ async function hybridSearch(query: string) {
 
 ## Embeddings
 
-### Local Provider
+### Repo Default
 ```typescript
-// Pros: Free, private, no API limits
-// Cons: Slower, uses CPU/GPU
+// Pros: No extra embedding credentials in the bundled setup
+// Tradeoff: Latency and resource cost depend on the configured provider
 
 import { generateEmbedding } from '@logan/libsql-search';
 
@@ -368,6 +380,6 @@ const embedding = await generateEmbedding(text, {
 
 ## Resources
 
-- **Transformers.js**: [huggingface.co/docs/transformers.js](https://huggingface.co/docs/transformers.js)
+- **libsql-search**: [github.com/llbbl/libsql-search](https://github.com/llbbl/libsql-search)
 - **Sentence Transformers**: [sbert.net](https://www.sbert.net/)
 - **Vector Search Explained**: [pinecone.io/learn/vector-database](https://www.pinecone.io/learn/vector-database/)

--- a/content/theme/overview.md
+++ b/content/theme/overview.md
@@ -5,7 +5,10 @@ tags: [astro, theme, documentation, semantic-search]
 
 # Semantic Docs Theme Overview
 
-Semantic Docs is a modern documentation theme built with Astro, featuring semantic vector search powered by libSQL and Turso. It combines static site generation with server-rendered search capabilities for a fast, searchable documentation experience.
+Semantic Docs is an Astro documentation theme with semantic search powered by
+`@logan/libsql-search` and a libSQL/Turso-compatible index. It combines
+pre-rendered article pages with a server-rendered search API so the site stays
+fast while search remains dynamic.
 
 **Reference Implementation**: Check out [Astro Vault](https://vault.llbbl.com) ([source](https://github.com/llbbl/astro-vault)) to see this theme in action with extensive documentation content.
 
@@ -13,9 +16,9 @@ Semantic Docs is a modern documentation theme built with Astro, featuring semant
 
 ### Semantic Vector Search
 - **Vector embeddings**: Content is indexed with 384-dimension embeddings
-- **Local embeddings**: Runs on-device with no API keys required
+- **Repo default**: The bundled setup uses libsql-search configured as `provider: 'local'`
 - **Fast semantic search**: Natural language queries return relevant results
-- **Edge-optimized**: Runs on Turso's edge database for low latency
+- **Flexible database path**: Works with a local libSQL file in development and Turso in remote deployments
 
 ### Static Site Generation
 - **Pre-rendered pages**: All documentation pages are built at compile time
@@ -27,13 +30,13 @@ Semantic Docs is a modern documentation theme built with Astro, featuring semant
 - **Rate limiting**: 20 requests per minute per IP
 - **Debounced requests**: Client waits 300ms before sending query
 - **Security**: Query validation, result limits, XSS protection
-- **Real-time**: Search API runs on Node.js adapter
+- **Real-time**: Search API runs through Astro's Node adapter
 
 ### Modern Tech Stack
-- **Astro 5**: Latest version with hybrid rendering
+- **Astro 7**: Server output with pre-rendered content routes
 - **Tailwind CSS 4**: Utility-first CSS with custom themes
 - **React 19**: For interactive components (search, TOC)
-- **TypeScript**: Full type safety across the codebase
+- **TypeScript 7**: Full type safety across the codebase
 - **Biome**: Fast linting and formatting
 - **Vitest**: Unit testing with browser mode
 
@@ -46,7 +49,7 @@ Semantic Docs is a modern documentation theme built with Astro, featuring semant
 │  or  local.db (Development)             │
 │                                         │
 │  - Vector embeddings (384-dim)          │
-│  - Full-text search                     │
+│  - Vector search index                  │
 │  - Metadata (tags, folders)             │
 └─────────────────────────────────────────┘
            ↑
@@ -64,7 +67,7 @@ Semantic Docs is a modern documentation theme built with Astro, featuring semant
 1. **Markdown files** in `./content/` directory
 2. **Indexing script** (`scripts/index-content.ts`) processes files:
    - Extracts frontmatter (title, tags)
-   - Generates embeddings
+   - Generates embeddings through libsql-search's configured provider
    - Stores in database with vectors
 3. **Build process** pre-renders all pages using database content
 4. **Runtime** serves static pages + dynamic search API
@@ -73,7 +76,7 @@ Semantic Docs is a modern documentation theme built with Astro, featuring semant
 1. User types query in search box
 2. Client debounces input (300ms)
 3. POST request to `/api/search.json` with `{ query, limit }`
-4. Server performs semantic search on Turso
+4. Server performs semantic search on the configured libSQL database
 5. Results ranked by cosine similarity
 6. Client displays results in dropdown
 
@@ -82,9 +85,11 @@ Semantic Docs is a modern documentation theme built with Astro, featuring semant
 ```
 semantic-docs/
 ├── content/               # Markdown documentation files
-│   ├── getting-started/  # Getting started guides
-│   ├── features/         # Feature documentation
-│   ├── theme/            # Theme documentation
+│   ├── getting-started/   # Getting started guides
+│   ├── features/          # Feature documentation
+│   ├── theme/             # Theme documentation
+│   └── ...
+├── docs/                  # Repo-level setup and operations docs
 │   └── ...
 ├── src/
 │   ├── components/       # Astro & React components
@@ -93,47 +98,51 @@ semantic-docs/
 │   │   ├── DocsToc.tsx
 │   │   └── Search.tsx
 │   ├── layouts/          # Page layouts
-│   │   └── Layout.astro
+│   │   └── DocsLayout.astro
 │   ├── pages/            # Route pages
 │   │   ├── index.astro
 │   │   ├── content/[...slug].astro
 │   │   └── api/search.json.ts
-│   ├── lib/              # Utilities
-│   │   └── turso.ts      # Database client
+│   ├── lib/              # Search config, env, and DB helpers
+│   │   ├── searchConfig.ts
+│   │   └── turso.ts
+│   ├── middleware/       # Rate limiting and request protections
 │   └── styles/           # Global styles
 │       └── global.css
 ├── scripts/              # Build scripts
 │   ├── init-db.ts        # Initialize database schema
 │   └── index-content.ts  # Index markdown to database
-└── public/               # Static assets
+├── justfile              # Optional task runner
+└── package.json
 ```
 
 ## Configuration
 
 ### Environment Variables
 ```bash
-# Production (Turso)
+# Remote libSQL / Turso
 TURSO_DB_URL=libsql://your-db.turso.io
 TURSO_AUTH_TOKEN=your-token
-
 ```
+
+When those values are not set, the project falls back to `file:local.db`.
 
 ### Astro Configuration
 ```typescript
 // astro.config.mjs
 export default defineConfig({
-  output: 'server',           // Hybrid rendering
-  adapter: node(),            // Node.js adapter for search API
-  integrations: [
-    react(),                  // React for interactive components
-    tailwindcss(),           // Tailwind CSS 4
-  ],
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
+  integrations: [react()],
+  vite: {
+    plugins: [tailwindcss()],
+  },
 });
 ```
 
 ## Theme System
 
-Astro Vault includes 6 built-in themes that can be switched at runtime:
+semantic-docs includes 6 built-in themes that can be switched at runtime:
 
 - **Dark** (default): High contrast dark theme
 - **Light**: Clean light theme
@@ -144,54 +153,25 @@ Astro Vault includes 6 built-in themes that can be switched at runtime:
 
 Themes are implemented with CSS variables and can be customized in `src/styles/global.css`.
 
-## Performance
+## Working in This Repo
 
-### Build Performance
-- **Incremental builds**: Only changed files are rebuilt
-- **Parallel processing**: Multiple pages built concurrently
-- **Fast embeddings**: Local embeddings run on CPU/GPU
-- **Efficient bundling**: Astro's optimized build pipeline
+Run the content index before builds so the database matches your Markdown:
 
-### Runtime Performance
-- **Static pages**: < 100ms load time
-- **Search latency**: ~50-200ms (Turso edge network)
-- **Small bundle size**: ~50KB JavaScript (gzipped)
-- **Lighthouse score**: 95+ on all metrics
-
-## Deployment
-
-### Docker
 ```bash
-# Build with Turso credentials
-docker build \
-  --build-arg TURSO_DB_URL=libsql://your-db.turso.io \
-  --build-arg TURSO_AUTH_TOKEN=your-token \
-  -t astro-vault .
-
-# Run
-docker run -p 4321:4321 \
-  -e TURSO_DB_URL=libsql://your-db.turso.io \
-  -e TURSO_AUTH_TOKEN=your-token \
-  astro-vault
+pnpm db:init:local
+pnpm index:local
+TURSO_DB_URL=file:local.db TURSO_AUTH_TOKEN=local pnpm build
 ```
 
-### Coolify
-1. Set build arguments: `TURSO_DB_URL`, `TURSO_AUTH_TOKEN`
-2. Set runtime environment variables (same values)
-3. Deploy - content is automatically indexed during build
-
-### Other Platforms
-- **Vercel**: Use `@astrojs/vercel` adapter
-- **Netlify**: Use `@astrojs/netlify` adapter
-- **Cloud Run**: Use Docker image
-- **Fly.io**: Use Docker image
+For remote libSQL/Turso deployments, use `pnpm db:init` and `pnpm index`
+instead.
 
 ## Customization
 
 ### Adding Content
 1. Create markdown files in `content/` directory
 2. Add frontmatter with title and tags
-3. Deploy - content is indexed automatically
+3. Re-run the index command before building or deploying
 
 ### Styling
 - Edit `src/styles/global.css` for global styles

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,70 @@
+# Deployment
+
+## Build Model
+
+`semantic-docs` uses:
+
+- `output: 'server'`
+- the Astro Node adapter
+- pre-rendered content pages
+- a server-rendered `/api/search.json` endpoint
+
+Do not switch the project to fully static output unless you are also replacing
+the search API behavior.
+
+## Deployment Flow
+
+For a Turso-backed deployment:
+
+```bash
+pnpm install
+pnpm db:init
+pnpm index
+pnpm build
+```
+
+For local verification without Turso credentials:
+
+```bash
+pnpm db:init:local
+pnpm index:local
+TURSO_DB_URL=file:local.db TURSO_AUTH_TOKEN=local pnpm build
+```
+
+If your shell or local `.env` already exports Turso credentials, the explicit
+local env vars keep the prerender build pointed at the indexed `file:local.db`
+database instead. When no Turso credentials are present, runtime database access
+already falls back to `file:local.db`.
+
+## Environment Variables
+
+Remote libSQL/Turso deployments use:
+
+```env
+TURSO_DB_URL=libsql://your-database.turso.io
+TURSO_AUTH_TOKEN=your-auth-token
+```
+
+Without those values, the project falls back to `file:local.db`.
+
+## Upgrade Note
+
+The current default index is `articles_local_384`. If you are upgrading from
+the older 768-dimension path, run:
+
+```bash
+pnpm db:init
+pnpm index
+```
+
+The legacy `articles` table can be retired separately after the new index is
+validated.
+
+## Platform Notes
+
+Any platform that can run the Astro Node adapter is a viable target. That
+includes traditional Node.js hosts and container-based deployments.
+
+The key requirement is that the search API remains server-rendered and the
+content index is built before release. If you change Markdown content, rerun the
+matching `pnpm index` or `pnpm index:local` command before the build.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,105 @@
+# Getting Started
+
+## Requirements
+
+- Node.js `>=22.13.0`
+- pnpm `11`
+
+## Install
+
+```bash
+git clone https://github.com/llbbl/semantic-docs.git
+cd semantic-docs
+pnpm install
+```
+
+You can also use the repository as a GitHub template.
+
+## Choose a Database Mode
+
+### Local libSQL for development and CI
+
+This path needs no credentials and writes to `file:local.db`.
+
+```bash
+pnpm db:init:local
+pnpm index:local
+pnpm dev
+```
+
+### Turso for a remote database
+
+Create a `.env` file and set:
+
+```env
+TURSO_DB_URL=libsql://your-database.turso.io
+TURSO_AUTH_TOKEN=your-auth-token
+```
+
+Then initialize and index:
+
+```bash
+pnpm db:init
+pnpm index
+pnpm dev
+```
+
+## Add Content
+
+Create Markdown files under `./content/<section>/<article>.md`.
+
+Example:
+
+```markdown
+---
+title: Getting Started
+tags: [tutorial, beginner]
+---
+
+# Getting Started
+
+Your content here.
+```
+
+After adding or changing content, rebuild the index before building or
+deploying:
+
+```bash
+pnpm index
+```
+
+Or, for the local database flow:
+
+```bash
+pnpm index:local
+```
+
+## Search Configuration
+
+The current repo configuration stores vectors in `articles_local_384` and uses:
+
+```ts
+embeddingOptions: {
+  provider: 'local',
+  dimensions: 384,
+}
+```
+
+Those values are defined in [`src/lib/searchConfig.ts`](../src/lib/searchConfig.ts)
+and used by both indexing and query paths. The application depends on the
+configured provider contract and vector shape, not on any specific embedding
+engine inside `@logan/libsql-search`.
+
+## Common Commands
+
+```bash
+pnpm dev
+pnpm build
+pnpm preview
+pnpm lint
+pnpm format
+pnpm test
+pnpm exec tsc --noEmit
+```
+
+If you prefer `just`, see [just.md](./just.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Documentation
+
+The root [`README.md`](../README.md) is the project landing page. This
+directory holds the setup, operational, and reference detail that would make
+the README too heavy.
+
+## Start Here
+
+- [Getting started](./GETTING_STARTED.md) for install, local development, Turso setup, and reindexing
+- [Deployment](./DEPLOYMENT.md) for build requirements, environment variables, and upgrade notes
+- [Reference](./REFERENCE.md) for project structure, search defaults, and quality commands
+- [Security](./SECURITY.md) for rate limiting and operational hardening notes
+- [Just tasks](./just.md) for the optional task-runner wrapper around the `pnpm` workflows

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,0 +1,60 @@
+# Reference
+
+## Project Structure
+
+```text
+semantic-docs/
+├── content/                    # Markdown source content
+├── docs/                       # Project and operational docs
+├── scripts/
+│   ├── init-db.ts              # Creates schema and vector index
+│   └── index-content.ts        # Indexes Markdown into libSQL/Turso
+├── src/
+│   ├── components/             # Header, sidebar, TOC, search UI
+│   ├── layouts/                # Shared page layout
+│   ├── lib/                    # Search config, env, db helpers
+│   ├── middleware/             # Rate limiting and request protections
+│   ├── pages/
+│   │   ├── api/search.json.ts  # Search API
+│   │   ├── content/[...slug].astro
+│   │   └── index.astro
+│   └── styles/                 # Global styles and theme variables
+├── astro.config.mjs
+├── justfile
+└── package.json
+```
+
+## Search Path
+
+1. `scripts/index-content.ts` reads Markdown from `./content`.
+2. `@logan/libsql-search` indexes the content into `articles_local_384`.
+3. Article pages are pre-rendered with Astro.
+4. `/api/search.json` performs semantic search at request time.
+
+## Current Search Defaults
+
+- table: `articles_local_384`
+- vector width: `384`
+- provider: `local`
+- local development database: `file:local.db` when Turso credentials are absent
+
+Those values are defined in [searchConfig.ts](../src/lib/searchConfig.ts).
+
+## Current Stack
+
+- Astro 7
+- React islands
+- Tailwind CSS 4
+- TypeScript 7
+- `@logan/libsql-search`
+
+## Release and Quality Commands
+
+```bash
+pnpm format
+pnpm lint
+pnpm exec tsc --noEmit
+pnpm test
+```
+
+Releases are driven from conventional commits on `main` via GitHub Actions.


### PR DESCRIPTION
## Summary
- refocus the README into a concise, value-first landing page for the project
- move setup, deployment, and reference detail into dedicated docs pages
- refresh semantic search docs with stable provider-contract and 384-dimension embedding wording

## Changes

### Documentation
- **README.md**: shorten the project entrypoint and link to detailed documentation
- **docs/README.md**: add the docs index for deeper guides
- **docs/GETTING_STARTED.md**: document installation, local setup, and indexing flow
- **docs/DEPLOYMENT.md**: document deployment requirements and build/index steps
- **docs/REFERENCE.md**: centralize configuration and operational reference details
- **content/features/semantic-search.md**: correct embedding and provider-contract language
- **content/theme/overview.md**: refresh theme/content docs for the current project framing

## Validation
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm test:coverage --run` (178 passed, 96.54% lines)
- [x] `pnpm db:init:local`
- [x] `pnpm index:local`
- [x] `TURSO_DB_URL=file:local.db TURSO_AUTH_TOKEN=local pnpm build`
- [x] Local link target checks
- [x] Independent docs review PASS after one finding was fixed

Closes #86
Closes #91