### PR TITLE
fix(docker): repair the container build after the Workers AI migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # Dependencies
 node_modules/
-pnpm-lock.yaml
 
 # Build output
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,23 @@
-# Production Dockerfile - Uses Turso database
-# Automatically indexes content to Turso during build
+# syntax=docker/dockerfile:1
+# Production Dockerfile - Uses Turso database and Cloudflare Workers AI.
+#
+# Build (BuildKit required; secrets are never written to image layers):
+#   docker build \
+#     --secret id=turso_db_url,env=TURSO_DB_URL \
+#     --secret id=turso_auth_token,env=TURSO_AUTH_TOKEN \
+#     --secret id=cloudflare_account_id,env=CLOUDFLARE_ACCOUNT_ID \
+#     --secret id=cloudflare_api_token,env=CLOUDFLARE_API_TOKEN \
+#     -t semantic-docs .
+#
+# Run (the same four values are needed again at runtime: every search embeds
+# its query through Workers AI and reads vectors from Turso):
+#   docker run -p 4321:4321 \
+#     -e TURSO_DB_URL -e TURSO_AUTH_TOKEN \
+#     -e CLOUDFLARE_ACCOUNT_ID -e CLOUDFLARE_API_TOKEN \
+#     semantic-docs
 
 # Build stage
 FROM node:22-slim AS builder
-
-# Build arguments for Turso credentials (required for indexing and pre-rendering)
-ARG TURSO_DB_URL
-ARG TURSO_AUTH_TOKEN
 
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
@@ -15,23 +26,35 @@ RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
 WORKDIR /app
 
 # Copy package files
-COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 # Copy source files
 COPY . .
 
-# Set environment variables for build
-ENV TURSO_DB_URL=$TURSO_DB_URL
-ENV TURSO_AUTH_TOKEN=$TURSO_AUTH_TOKEN
+# Index content into Turso. Needs Workers AI credentials as well as Turso ones:
+# indexing embeds every chunk through @cf/baai/bge-m3. `required=true` fails the
+# build with a named secret rather than letting the script exit 1 on its own.
+RUN --mount=type=secret,id=turso_db_url,required=true \
+    --mount=type=secret,id=turso_auth_token,required=true \
+    --mount=type=secret,id=cloudflare_account_id,required=true \
+    --mount=type=secret,id=cloudflare_api_token,required=true \
+    export TURSO_DB_URL="$(cat /run/secrets/turso_db_url)" && \
+    export TURSO_AUTH_TOKEN="$(cat /run/secrets/turso_auth_token)" && \
+    export CLOUDFLARE_ACCOUNT_ID="$(cat /run/secrets/cloudflare_account_id)" && \
+    export CLOUDFLARE_API_TOKEN="$(cat /run/secrets/cloudflare_api_token)" && \
+    pnpm exec tsx scripts/init-db.ts && \
+    pnpm exec tsx scripts/index-content.ts
 
-# Index content to Turso database (env vars already set via ENV directives)
-RUN pnpm exec tsx scripts/init-db.ts && pnpm exec tsx scripts/index-content.ts
-
-# Build application (queries Turso database for static pre-rendering)
-RUN pnpm build
+# Pre-render content pages. Reads articles back out of Turso, so it needs those
+# credentials but not the Workers AI ones.
+RUN --mount=type=secret,id=turso_db_url,required=true \
+    --mount=type=secret,id=turso_auth_token,required=true \
+    export TURSO_DB_URL="$(cat /run/secrets/turso_db_url)" && \
+    export TURSO_AUTH_TOKEN="$(cat /run/secrets/turso_auth_token)" && \
+    pnpm build
 
 # Production stage
 FROM node:22-slim AS runtime
@@ -43,14 +66,15 @@ RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
 WORKDIR /app
 
 # Copy package files
-COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install production dependencies only
-RUN pnpm install --prod --no-frozen-lockfile
+RUN pnpm install --prod --frozen-lockfile
 
-# Copy built application from builder
+# Copy built application from builder. No local.db: this image reads from Turso,
+# and shipping an empty file would let a credential-less container start up
+# quietly serving nothing.
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/local.db ./local.db
 
 # Create non-root user
 RUN groupadd -g 1001 nodejs && \
@@ -69,9 +93,12 @@ EXPOSE 4321
 ENV HOST=0.0.0.0
 ENV PORT=4321
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:4321/', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+# Health check. Hits the search-readiness endpoint rather than `/`, which is
+# prerendered and would report healthy on a container that cannot search.
+# 127.0.0.1 rather than localhost: the server binds IPv4 only, and localhost
+# can resolve to ::1 first.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:4321/api/health.json',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 # Start the server
 CMD ["node", "./dist/server/entry.mjs"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,17 @@
-# Dockerfile for local development and testing with embedded SQLite (local.db)
+# syntax=docker/dockerfile:1
+# Dockerfile for local development and testing with embedded SQLite (local.db).
+#
+# Indexing still embeds through Workers AI, so a build needs those credentials
+# even though the database is a local file:
+#   docker build -f Dockerfile.local \
+#     --secret id=cloudflare_account_id,env=CLOUDFLARE_ACCOUNT_ID \
+#     --secret id=cloudflare_api_token,env=CLOUDFLARE_API_TOKEN \
+#     -t semantic-docs-local .
+#
+# Serving search needs them again at runtime:
+#   docker run -p 4321:4321 \
+#     -e CLOUDFLARE_ACCOUNT_ID -e CLOUDFLARE_API_TOKEN \
+#     semantic-docs-local
 
 # Build stage
 FROM node:22-slim AS builder
@@ -10,16 +23,22 @@ RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
 WORKDIR /app
 
 # Copy package files
-COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install dependencies
-RUN pnpm install --no-frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 # Copy source files
 COPY . .
 
-# Initialize database and index content for build
-RUN pnpm db:init:local && pnpm index:local
+# Initialize local.db and index content into it. No Turso credentials, so both
+# scripts fall back to file:local.db; the Workers AI ones are still required
+# because indexing embeds every chunk.
+RUN --mount=type=secret,id=cloudflare_account_id,required=true \
+    --mount=type=secret,id=cloudflare_api_token,required=true \
+    export CLOUDFLARE_ACCOUNT_ID="$(cat /run/secrets/cloudflare_account_id)" && \
+    export CLOUDFLARE_API_TOKEN="$(cat /run/secrets/cloudflare_api_token)" && \
+    pnpm db:init:local && pnpm index:local
 
 # Build application
 RUN pnpm build
@@ -34,12 +53,12 @@ RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
 WORKDIR /app
 
 # Copy package files
-COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Install production dependencies only
-RUN pnpm install --prod --no-frozen-lockfile
+RUN pnpm install --prod --frozen-lockfile
 
-# Copy built application and local.db
+# Copy built application and the indexed database
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/local.db ./local.db
 
@@ -60,9 +79,12 @@ EXPOSE 4321
 ENV HOST=0.0.0.0
 ENV PORT=4321
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:4321/', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+# Health check. Hits the search-readiness endpoint rather than `/`, which is
+# prerendered and would report healthy on a container that cannot search.
+# 127.0.0.1 rather than localhost: the server binds IPv4 only, and localhost
+# can resolve to ::1 first.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:4321/api/health.json',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 # Start the server
 CMD ["node", "./dist/server/entry.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,27 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.local
+      secrets:
+        - cloudflare_account_id
+        - cloudflare_api_token
     ports:
       - "4321:4321"
     environment:
       - HOST=0.0.0.0
       - PORT=4321
+      # Serving a search embeds the query through Workers AI, so the container
+      # needs these at runtime as well as at build time.
+      - CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID:?set CLOUDFLARE_ACCOUNT_ID in your environment or .env}
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN in your environment or .env}
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:4321/', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:4321/api/health.json',(r)=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
       interval: 30s
-      timeout: 3s
+      timeout: 5s
       retries: 3
-      start_period: 5s
+      start_period: 15s
+
+secrets:
+  cloudflare_account_id:
+    environment: CLOUDFLARE_ACCOUNT_ID
+  cloudflare_api_token:
+    environment: CLOUDFLARE_API_TOKEN

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -70,6 +70,66 @@ pnpm index
 The legacy `articles` and `articles_local_384` tables can be retired separately
 once the new index is validated.
 
+## Containers
+
+Two Dockerfiles are provided. Both index content during the build, and indexing
+embeds every chunk through Workers AI, so **both need Cloudflare credentials at
+build time as well as at runtime**. Builds require BuildKit, which is the
+default in current Docker; credentials are passed as build secrets so they are
+never written into an image layer.
+
+`Dockerfile` builds against Turso and ships no database file — the running
+container reads vectors from Turso:
+
+```bash
+docker build \
+  --secret id=turso_db_url,env=TURSO_DB_URL \
+  --secret id=turso_auth_token,env=TURSO_AUTH_TOKEN \
+  --secret id=cloudflare_account_id,env=CLOUDFLARE_ACCOUNT_ID \
+  --secret id=cloudflare_api_token,env=CLOUDFLARE_API_TOKEN \
+  -t semantic-docs .
+
+docker run -p 4321:4321 \
+  -e TURSO_DB_URL -e TURSO_AUTH_TOKEN \
+  -e CLOUDFLARE_ACCOUNT_ID -e CLOUDFLARE_API_TOKEN \
+  semantic-docs
+```
+
+`Dockerfile.local` indexes into a `local.db` that is baked into the image, so it
+needs no Turso credentials — but it still needs the Cloudflare pair in both
+phases:
+
+```bash
+docker build -f Dockerfile.local \
+  --secret id=cloudflare_account_id,env=CLOUDFLARE_ACCOUNT_ID \
+  --secret id=cloudflare_api_token,env=CLOUDFLARE_API_TOKEN \
+  -t semantic-docs-local .
+
+docker run -p 4321:4321 \
+  -e CLOUDFLARE_ACCOUNT_ID -e CLOUDFLARE_API_TOKEN \
+  semantic-docs-local
+```
+
+`docker compose up --build` runs the `Dockerfile.local` path and reads both
+Cloudflare values from your environment or `.env`, failing with a named error if
+either is unset.
+
+A missing build secret fails the build immediately, before any dependency
+install, rather than partway through indexing.
+
+### Health Endpoint
+
+`GET /api/health.json` reports whether the instance can actually serve a search:
+
+```json
+{ "status": "ok", "checks": { "database": true, "embeddings": true } }
+```
+
+It returns 503 when the search table cannot be read or the Workers AI
+credentials are absent. Both images use it as their `HEALTHCHECK`. Do not point
+a healthcheck at `/` — that page is prerendered and answers 200 from a container
+whose database is unreachable.
+
 ## Platform Notes
 
 Any platform that can run the Astro Node adapter is a viable target. That

--- a/src/pages/api/health.json.test.ts
+++ b/src/pages/api/health.json.test.ts
@@ -1,0 +1,86 @@
+import type { APIContext } from 'astro';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './health.json';
+
+vi.mock('../../lib/turso', () => ({
+  getTursoClient: vi.fn(),
+}));
+
+const { getTursoClient } = await import('../../lib/turso');
+
+function mockDb(execute: () => Promise<unknown>) {
+  vi.mocked(getTursoClient).mockReturnValue({
+    execute,
+  } as unknown as ReturnType<typeof getTursoClient>);
+}
+
+const context = {} as APIContext;
+
+describe('Health API Route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', 'test-account-id');
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', 'test-api-token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should report ok when the search table reads and credentials are set', async () => {
+    mockDb(() => Promise.resolve({ rows: [] }));
+
+    const response = await GET(context);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: 'ok',
+      checks: { database: true, embeddings: true },
+    });
+  });
+
+  it('should query the search table rather than only pinging the connection', async () => {
+    const execute = vi.fn(() => Promise.resolve({ rows: [] }));
+    mockDb(execute);
+
+    await GET(context);
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('articles_cf_bgem3_1024'),
+    );
+  });
+
+  it('should report unhealthy when the database is unreachable', async () => {
+    mockDb(() => Promise.reject(new Error('connection refused')));
+
+    const response = await GET(context);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: 'unhealthy',
+      checks: { database: false, embeddings: true },
+    });
+  });
+
+  it('should report unhealthy when Workers AI credentials are missing', async () => {
+    mockDb(() => Promise.resolve({ rows: [] }));
+    vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', '');
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', '');
+
+    const response = await GET(context);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      status: 'unhealthy',
+      checks: { database: true, embeddings: false },
+    });
+  });
+
+  it('should never let an orchestrator cache the verdict', async () => {
+    mockDb(() => Promise.resolve({ rows: [] }));
+
+    const response = await GET(context);
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+});

--- a/src/pages/api/health.json.ts
+++ b/src/pages/api/health.json.ts
@@ -1,0 +1,54 @@
+/**
+ * Health Check Endpoint
+ * Reports whether this instance can actually serve search, not merely whether
+ * the process is up.
+ */
+
+import type { APIRoute } from 'astro';
+import { logger } from 'logan-logger';
+import { env } from '@/lib/env';
+import { SEARCH_TABLE_NAME } from '@/lib/searchConfig';
+import { getTursoClient } from '@/lib/turso';
+
+export const prerender = false;
+
+const securityHeaders = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'",
+  // An orchestrator polling this must never be handed a cached verdict.
+  'Cache-Control': 'no-store',
+};
+
+/**
+ * Reads from the search table rather than pinging the connection, so a
+ * database that is reachable but was never indexed still reports unhealthy.
+ */
+async function isDatabaseReady(): Promise<boolean> {
+  try {
+    await getTursoClient().execute(
+      `SELECT 1 FROM ${SEARCH_TABLE_NAME} LIMIT 1`,
+    );
+    return true;
+  } catch (error) {
+    logger.error('Health check: search table unavailable', error);
+    return false;
+  }
+}
+
+export const GET: APIRoute = async () => {
+  const database = await isDatabaseReady();
+  const embeddings = env.hasCloudflareCredentials;
+  const healthy = database && embeddings;
+
+  return new Response(
+    JSON.stringify({
+      status: healthy ? 'ok' : 'unhealthy',
+      checks: { database, embeddings },
+    }),
+    {
+      status: healthy ? 200 : 503,
+      headers: { 'Content-Type': 'application/json', ...securityHeaders },
+    },
+  );
+};


### PR DESCRIPTION
## Summary

Issue #101 identified six problems left behind when the search backend migrated to Cloudflare Workers AI (#100), all of which broke the container build/runtime path. This PR addresses each:

1. **Indexing had no way to receive Workers AI credentials.** `pnpm index` now exits non-zero without `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`, but the Dockerfiles only ever plumbed Turso credentials through `ARG`/`ENV`. Both Dockerfiles now accept all four credentials as BuildKit secrets (`--mount=type=secret`, `required=true`), which keeps them out of image layer metadata and fails the build immediately with a named missing secret instead of a late script failure.
2. **The lockfile never reached the build context.** `.dockerignore` excluded `pnpm-lock.yaml`, so `--frozen-lockfile` was never usable. It's no longer excluded, and both stages of both Dockerfiles now run `pnpm install --frozen-lockfile` instead of `--no-frozen-lockfile`.
3. **The production runtime shipped a stale/irrelevant `local.db`.** The production `Dockerfile` copied `/app/local.db` into the runtime image even though the production path reads from Turso and never creates that file. That copy is removed — the production image ships no local database file at all.
4. **The runtime container needs Workers AI credentials too.** Every search embeds its query through Workers AI at request time, not just at index time. `docker-compose.yml` now passes `CLOUDFLARE_ACCOUNT_ID`/`CLOUDFLARE_API_TOKEN` through as required runtime environment variables (with `:?` guards), and `Dockerfile.local`'s build stage takes them as build secrets since indexing happens during that build.
5. **The healthcheck couldn't detect a broken search path.** Both Dockerfiles and `docker-compose.yml` hit `/`, a prerendered static page that returns 200 regardless of database or embedding state. All three now hit the new `GET /api/health.json` endpoint, which checks the database connection and the presence of Workers AI credentials and returns 503 if either is unhealthy.
6. **No documentation for the container deployment path.** `docs/DEPLOYMENT.md` gains new "Containers" and "Health Endpoint" sections covering the secret-passing build/run commands and what the health endpoint reports.

## Changes

### Docker Build
- **Dockerfile**: BuildKit secret mounts for Turso + Cloudflare credentials, `--frozen-lockfile` in both stages, removed the stale `local.db` copy from the runtime stage, updated `HEALTHCHECK` to hit `/api/health.json` over `127.0.0.1`
- **Dockerfile.local**: same secret-mount and frozen-lockfile treatment, plus Cloudflare secrets required for the local indexing build stage
- **docker-compose.yml**: `secrets:` block for build-time Cloudflare credentials, required runtime `CLOUDFLARE_ACCOUNT_ID`/`CLOUDFLARE_API_TOKEN` env vars, updated healthcheck target and timing
- **.dockerignore**: no longer excludes `pnpm-lock.yaml`, so it reaches the build context

### Features
- **src/pages/api/health.json.ts**: new `GET /api/health.json` endpoint reporting database and Workers AI credential health, returning 503 on any failed check

### Tests
- **src/pages/api/health.json.test.ts**: 5 tests covering the healthy path and each failure mode

### Documentation
- **docs/DEPLOYMENT.md**: new "Containers" and "Health Endpoint" sections

## Verification

- `docker build --check` reports no warnings for both Dockerfiles
- `docker compose config` validates
- A build with no secrets fails immediately with `secret cloudflare_account_id: not found`, before dependency install
- A build with dummy secrets gets through `pnpm install --frozen-lockfile` in both stages and reaches the indexing step, failing only on the fake Cloudflare account — confirming the lockfile and credential plumbing work
- `pnpm-lock.yaml` confirmed present in the build context
- `pnpm build` succeeds and bundles the health route
- Running the built server with Turso but no Cloudflare credentials: `/` returns 200 while `/api/health.json` returns 503 with `{"status":"unhealthy","checks":{"database":true,"embeddings":false}}` — the exact case the old healthcheck missed
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm test` (195 tests, 13 files) pass; the new endpoint is at 100% coverage

**Not verified**: a full successful image build was not run, because no Cloudflare credentials are present in this environment (`.env` has only `TURSO_DB_URL`, `TURSO_AUTH_TOKEN`, `VAULT_PATH`). The success path of indexing inside the container is therefore untested here.

Closes #101
