### PR TITLE
ci: stop bumping the major version automatically

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,6 +3,12 @@ name: Auto Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      allow_major:
+        description: 'Cut a major release. Leave off unless a major is deliberately intended.'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -35,30 +41,30 @@ jobs:
 
       - name: Determine next version
         id: version
+        env:
+          ALLOW_MAJOR: ${{ inputs.allow_major || false }}
         run: |
           latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "latest=$latest_tag" >> "$GITHUB_OUTPUT"
 
-          version="${latest_tag#v}"
-          IFS='.' read -r major minor patch <<< "$version"
-
           commits=$(git log "$latest_tag"..HEAD --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
 
-          if echo "$commits" | grep -qE "^feat(\(.+\))?!:|^fix(\(.+\))?!:|^refactor(\(.+\))?!:|BREAKING CHANGE"; then
-            major=$((major + 1))
-            minor=0
-            patch=0
-          elif echo "$commits" | grep -qE "^feat(\(.+\))?:"; then
-            minor=$((minor + 1))
-            patch=0
-          else
-            patch=$((patch + 1))
+          printf '%s\n' "$commits" \
+            | ./scripts/next-version.sh "$latest_tag" "$ALLOW_MAJOR" > version.out
+          cat version.out >> "$GITHUB_OUTPUT"
+
+          version=$(grep '^version=' version.out | cut -d= -f2)
+          bump=$(grep '^bump=' version.out | cut -d= -f2)
+          suppressed=$(grep '^suppressed_major=' version.out | cut -d= -f2)
+          rm -f version.out
+
+          echo "next=v$version" >> "$GITHUB_OUTPUT"
+
+          if [ "$suppressed" = "true" ]; then
+            echo "::warning::A breaking-change marker was found in the commits since $latest_tag, but automatic major bumps are disabled. Releasing v$version as a $bump instead. To cut a major, run this workflow manually with allow_major enabled."
           fi
 
-          next="v${major}.${minor}.${patch}"
-          echo "next=$next" >> "$GITHUB_OUTPUT"
-          echo "version=${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
-          echo "Next version: $next (from $latest_tag)"
+          echo "Next version: v$version ($bump, from $latest_tag)"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,16 @@ chore: bump dependencies
 ```
 
 ### Release Process
-1. Make commits following the convention above
-2. Create and push a version tag: `git tag v1.2.3 && git push --tags`
-3. GitHub Actions will automatically generate changelog and create release
+
+Pushing to `main` cuts a release automatically — do not tag by hand. The
+workflow reads conventional commit subjects since the last tag, bumps the
+version, commits the bump, tags it, and publishes a GitHub release.
+
+**This project does not follow strict semver.** `feat:` bumps the minor,
+everything else bumps the patch, and a breaking-change marker (`feat!:`,
+`fix!:`, `refactor!:`, `BREAKING CHANGE`) also bumps only the **minor** — it
+logs a warning rather than cutting a major. Majors are cut deliberately by
+running the Auto Release workflow manually with `allow_major` enabled.
+
+This means the squash-merge subject decides the release. Choose it carefully:
+it is the version bump. See `docs/REFERENCE.md` for the full table.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -58,3 +58,27 @@ pnpm test
 ```
 
 Releases are driven from conventional commits on `main` via GitHub Actions.
+
+## Versioning
+
+**This project does not follow strict semver.** Breaking changes ship in minor
+releases. The version number tracks release cadence, not compatibility
+guarantees — read the changelog, not the version, before upgrading.
+
+Releases are cut automatically from conventional commit subjects on `main`:
+
+| Commit subject since the last tag | Bump |
+| --- | --- |
+| `feat:` / `feat(scope):` | minor |
+| anything else | patch |
+| `feat!:`, `fix!:`, `refactor!:`, `BREAKING CHANGE` | minor, with a warning |
+
+A breaking-change marker does **not** produce a major on its own. Majors are
+deliberate: run the Auto Release workflow manually from the Actions tab with
+`allow_major` enabled. When a marker is found and suppressed, the run logs a
+warning naming the version it shipped instead.
+
+The decision lives in [`scripts/next-version.sh`](../scripts/next-version.sh)
+rather than inline in the workflow, so it can be tested without cutting a
+release. Only commit *subjects* are inspected — a `BREAKING CHANGE` footer in a
+commit body has never been detected.

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Decides the next release version from commit subjects since the last tag.
+#
+# Usage:  git log <tag>..HEAD --pretty=format:%s | next-version.sh <latest-tag> [allow-major]
+# Output: version=X.Y.Z / bump=major|minor|patch / suppressed_major=true|false
+#         (key=value lines, appendable straight to $GITHUB_OUTPUT)
+#
+# Major bumps are opt-in. This project does not follow strict semver: a
+# breaking-change marker produces a minor, and majors are cut deliberately by
+# a human running the release workflow with allow-major set.
+
+set -euo pipefail
+
+latest_tag="${1:-v0.0.0}"
+allow_major="${2:-false}"
+
+version="${latest_tag#v}"
+IFS='.' read -r major minor patch <<<"$version"
+
+major=${major:-0}
+minor=${minor:-0}
+patch=${patch:-0}
+
+commits=$(cat)
+
+# Subjects only, matching what the workflow pipes in; a BREAKING CHANGE footer
+# in a commit body is not seen here and never was.
+breaking_re='^feat(\(.+\))?!:|^fix(\(.+\))?!:|^refactor(\(.+\))?!:|BREAKING CHANGE'
+feature_re='^feat(\(.+\))?:'
+
+suppressed_major=false
+
+if printf '%s\n' "$commits" | grep -qE "$breaking_re"; then
+  if [ "$allow_major" = "true" ]; then
+    bump='major'
+    major=$((major + 1))
+    minor=0
+    patch=0
+  else
+    bump='minor'
+    suppressed_major=true
+    minor=$((minor + 1))
+    patch=0
+  fi
+elif printf '%s\n' "$commits" | grep -qE "$feature_re"; then
+  bump='minor'
+  minor=$((minor + 1))
+  patch=0
+else
+  bump='patch'
+  patch=$((patch + 1))
+fi
+
+echo "version=${major}.${minor}.${patch}"
+echo "bump=${bump}"
+echo "suppressed_major=${suppressed_major}"

--- a/scripts/next-version.test.ts
+++ b/scripts/next-version.test.ts
@@ -1,0 +1,108 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+/** Runs the release script the way the workflow does: subjects on stdin. */
+function nextVersion(
+  latestTag: string,
+  subjects: string[],
+  allowMajor = false,
+): Record<string, string> {
+  const stdout = execFileSync(
+    './scripts/next-version.sh',
+    [latestTag, String(allowMajor)],
+    { input: subjects.join('\n'), encoding: 'utf8' },
+  );
+
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split('\n')
+      .map((line) => line.split('=') as [string, string]),
+  );
+}
+
+describe('next-version.sh', () => {
+  it('should bump the patch for a fix', () => {
+    expect(nextVersion('v2.1.0', ['fix: a thing'])).toEqual({
+      version: '2.1.1',
+      bump: 'patch',
+      suppressed_major: 'false',
+    });
+  });
+
+  it('should bump the minor for a feature', () => {
+    expect(nextVersion('v2.1.0', ['feat: a thing'])).toMatchObject({
+      version: '2.2.0',
+      bump: 'minor',
+    });
+  });
+
+  it('should bump the minor for a scoped feature', () => {
+    expect(nextVersion('v2.1.0', ['feat(theme): a thing'])).toMatchObject({
+      version: '2.2.0',
+      bump: 'minor',
+    });
+  });
+
+  it('should NOT bump the major for a breaking change by default', () => {
+    expect(nextVersion('v2.1.0', ['feat(search)!: reshape the API'])).toEqual({
+      version: '2.2.0',
+      bump: 'minor',
+      suppressed_major: 'true',
+    });
+  });
+
+  it.each([
+    'feat!: a thing',
+    'fix!: a thing',
+    'refactor!: a thing',
+    'feat(search)!: a thing',
+    'chore: mentions BREAKING CHANGE somewhere',
+  ])('should suppress the major for %s', (subject) => {
+    const result = nextVersion('v2.1.0', [subject]);
+    expect(result.bump).toBe('minor');
+    expect(result.suppressed_major).toBe('true');
+  });
+
+  it('should bump the major only when explicitly allowed', () => {
+    expect(
+      nextVersion('v2.1.0', ['feat(search)!: reshape the API'], true),
+    ).toEqual({
+      version: '3.0.0',
+      bump: 'major',
+      suppressed_major: 'false',
+    });
+  });
+
+  it('should not invent a major from a non-breaking commit even when allowed', () => {
+    expect(nextVersion('v2.1.0', ['feat: a thing'], true)).toMatchObject({
+      version: '2.2.0',
+      bump: 'minor',
+    });
+  });
+
+  it('should take the highest bump across a mixed batch', () => {
+    expect(
+      nextVersion('v2.1.0', ['fix: a', 'feat: b', 'docs: c']),
+    ).toMatchObject({ version: '2.2.0', bump: 'minor' });
+  });
+
+  it('should suppress the major when a breaking commit is mixed in', () => {
+    expect(
+      nextVersion('v2.1.0', ['fix: a', 'feat!: b', 'docs: c']),
+    ).toMatchObject({ version: '2.2.0', suppressed_major: 'true' });
+  });
+
+  it('should treat an unrecognized subject as a patch', () => {
+    expect(nextVersion('v2.1.0', ['whatever this is'])).toMatchObject({
+      version: '2.1.1',
+      bump: 'patch',
+    });
+  });
+
+  it('should start from zero when no tag exists', () => {
+    expect(nextVersion('v0.0.0', ['docs: first'])).toMatchObject({
+      version: '0.0.1',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A single `!` in a squash-merge subject (`feat!:`, `fix!:`, a `BREAKING CHANGE` footer, etc.) was enough to ship a new major version, decided at merge time with no confirmation step. This PR removes that automatic path: a breaking-change marker now produces a minor bump instead, and the workflow logs a warning naming the version it shipped so the decision is visible after the fact. Majors become deliberate — they only happen via a manual run from the Actions tab with the new `allow_major` input enabled.

This project is no longer following strict semver, so that policy is now written down in `docs/REFERENCE.md` and `CLAUDE.md` rather than left implied by the tag numbers.

The version decision itself moves out of inline workflow bash into `scripts/next-version.sh`, which both the workflow and a new test suite call. Previously this logic was impossible to exercise without actually pushing to `main`.

## Changes

### CI / Release Workflow
- **.github/workflows/auto-release.yml**: Replace inline major/minor/patch bump logic with a call to `scripts/next-version.sh`; add the `allow_major` boolean workflow_dispatch input (default `false`); log a warning when a breaking-change marker is suppressed to a minor

### Scripts
- **scripts/next-version.sh**: New script — computes the next semver version from commit subjects and a flag for whether major bumps are allowed; suppresses breaking-change markers to a minor bump unless explicitly allowed
- **scripts/next-version.test.ts**: New unit test suite covering the version-decision logic

### Documentation
- **docs/REFERENCE.md**: Document the versioning policy — this project no longer follows strict semver for majors, and how to opt into a major bump
- **CLAUDE.md**: Note the same policy for future Claude Code sessions working in this repo

## Verification

- `scripts/next-version.sh` covered by 15 unit tests: patch, minor, scoped minor, each breaking marker suppressed (`feat!:`, `fix!:`, `refactor!:`, `feat(scope)!:`, `BREAKING CHANGE`), breaking-allowed producing a major, mixed batches, unrecognized subjects, and the no-tag case
- Smoke-checked directly: from `v2.1.0`, `fix:` → 2.1.1, `feat:` → 2.2.0, `feat(search)!:` → 2.2.0 with `suppressed_major=true`, and `feat(search)!:` with allow_major → 3.0.0
- Workflow YAML parses; triggers are `push` and `workflow_dispatch`, with the `allow_major` boolean input defaulting to false
- `shellcheck scripts/next-version.sh` is clean
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm test` (224 tests, 15 files) pass

Note: this PR itself lands as a patch (v2.1.1). On a `push` event, `inputs.allow_major` is empty, so `ALLOW_MAJOR` resolves to `false` — the opt-in is only reachable via manual `workflow_dispatch`.

Closes #114