### PR TITLE
feat(search): return excerpts and cache results per process

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,9 @@ CLOUDFLARE_API_TOKEN=your-api-token
 # For X-Forwarded-For, trusted hops are counted from the right of the chain.
 # RATE_LIMIT_TRUSTED_PROXY_HOPS=1
 # RATE_LIMIT_MAX_ENTRIES=10000
+
+# Per-process cache of search results, keyed by normalized query + limit.
+# A hit skips the billed Workers AI embedding call entirely.
+# Set the TTL to 0 to disable caching.
+# SEARCH_CACHE_TTL_SECONDS=300
+# SEARCH_CACHE_MAX_ENTRIES=500

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -37,8 +37,15 @@ semantic-docs/
 - vector width: `1024` (fixed by `@cf/baai/bge-m3`)
 - provider: `cloudflare` (Workers AI; requires `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`)
 - local development database: `file:local.db` when Turso credentials are absent
+- result cache: 500 entries, 5 minute TTL, per process
+  (`SEARCH_CACHE_TTL_SECONDS`, `SEARCH_CACHE_MAX_ENTRIES`; `0` disables)
 
 Those values are defined in [searchConfig.ts](../src/lib/searchConfig.ts).
+
+`/api/search.json` returns `id, slug, title, folder, tags, distance, excerpt`.
+The excerpt is a ~160 character plain-text window built by
+[excerpt.ts](../src/lib/excerpt.ts), centered on the first query term where the
+article contains one. Article bodies are never sent to the client.
 
 ## Current Stack
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -104,6 +104,13 @@ The API limits:
 - Results count (max 20) - prevents excessive database queries
 - Request rate (20/min) - prevents API/database abuse
 
+A per-process result cache sits in front of the embedding call, so repeated
+queries cost nothing upstream. It is keyed by normalized query and limit, holds
+500 entries for 5 minutes by default, and is tuned with
+`SEARCH_CACHE_TTL_SECONDS` and `SEARCH_CACHE_MAX_ENTRIES`. Setting the TTL to 0
+disables it. The cache is per instance, so it reduces call volume rather than
+bounding it; it is not a substitute for a spend cap.
+
 ### Environment-Specific Risks
 
 **Cloudflare Workers AI embedding provider**
@@ -115,8 +122,12 @@ The API limits:
   Cloudflare. Do not index material you cannot share with a third party.
 - Risk: Availability coupling. There is no in-process fallback; a Workers AI
   outage takes search down.
-- Mitigation: Rate limiting bounds a single client only. Set a Workers AI usage
-  cap in the Cloudflare dashboard for a real spend ceiling.
+- Mitigation: Rate limiting bounds a single client only, and the result cache
+  collapses repeated queries. Neither bounds total spend. Set a Workers AI usage
+  cap in the Cloudflare dashboard for a real ceiling.
+- Note: While a query is cached, results are served without contacting
+  Cloudflare, so broken or revoked credentials surface only once the entry
+  expires rather than on the next request.
 
 ### Credential Handling
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -21,6 +21,7 @@ interface SearchResult {
   folder: string;
   tags: string[];
   distance: number;
+  excerpt: string;
 }
 
 export interface SearchProps {
@@ -265,6 +266,11 @@ export default function Search({
                         <div className="font-medium text-sm">
                           {result.title}
                         </div>
+                        {result.excerpt && (
+                          <div className="text-xs text-muted-foreground line-clamp-2 text-left">
+                            {result.excerpt}
+                          </div>
+                        )}
                         {result.tags.length > 0 && (
                           <div className="flex flex-wrap gap-1">
                             {result.tags.map((tag) => (

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -51,6 +51,14 @@ export function getRequiredEnv(key: string): string {
 
 export type RateLimitTrustedProxyHeader = 'x-real-ip' | 'x-forwarded-for';
 
+function getNonNegativeInteger(key: string, defaultValue: number): number {
+  const value = getEnv(key);
+  if (value === undefined) return defaultValue;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : defaultValue;
+}
+
 function getPositiveInteger(key: string, defaultValue: number): number {
   const value = getEnv(key);
   if (value === undefined) return defaultValue;
@@ -111,6 +119,16 @@ export const env = {
   /** Maximum in-memory rate-limit buckets retained per process */
   get rateLimitMaxEntries(): number {
     return getPositiveInteger('RATE_LIMIT_MAX_ENTRIES', 10_000);
+  },
+
+  /** Search result cache lifetime. Zero disables the cache. */
+  get searchCacheTtlMs(): number {
+    return getNonNegativeInteger('SEARCH_CACHE_TTL_SECONDS', 300) * 1000;
+  },
+
+  /** Maximum cached search responses retained per process */
+  get searchCacheMaxEntries(): number {
+    return getPositiveInteger('SEARCH_CACHE_MAX_ENTRIES', 500);
   },
 
   /**

--- a/src/lib/excerpt.test.ts
+++ b/src/lib/excerpt.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { buildExcerpt, toPlainText } from './excerpt';
+
+describe('toPlainText', () => {
+  it('should keep underscores inside identifiers', () => {
+    const text = toPlainText(
+      'Use vector_distance_cos with TURSO_DB_URL and CLOUDFLARE_ACCOUNT_ID.',
+    );
+    expect(text).toContain('vector_distance_cos');
+    expect(text).toContain('TURSO_DB_URL');
+    expect(text).toContain('CLOUDFLARE_ACCOUNT_ID');
+  });
+
+  it('should still strip underscore emphasis at word boundaries', () => {
+    expect(toPlainText('a _stressed_ word')).toBe('a stressed word');
+    expect(toPlainText('a __very__ stressed word')).toBe(
+      'a very stressed word',
+    );
+  });
+
+  it('should strip asterisk emphasis', () => {
+    expect(toPlainText('a **bold** and *italic* word')).toBe(
+      'a bold and italic word',
+    );
+  });
+
+  it('should strip strikethrough', () => {
+    expect(toPlainText('a ~~struck~~ word')).toBe('a struck word');
+  });
+
+  it('should drop fenced code blocks', () => {
+    const text = toPlainText('Intro text\n\n```sql\nSELECT 1;\n```\n\nOutro');
+    expect(text).not.toContain('SELECT 1');
+    expect(text).toContain('Intro text');
+    expect(text).toContain('Outro');
+  });
+
+  it('should unwrap inline code without losing its contents', () => {
+    expect(toPlainText('run `pnpm index` now')).toBe('run pnpm index now');
+  });
+
+  it('should reduce links and images to their text', () => {
+    expect(toPlainText('see [the docs](https://example.com) here')).toBe(
+      'see the docs here',
+    );
+    expect(toPlainText('![a diagram](/x.png)')).toBe('a diagram');
+  });
+
+  it('should strip heading, quote, and list markers', () => {
+    expect(
+      toPlainText('## Title\n\n> quoted\n\n- one\n- two\n\n1. three'),
+    ).toBe('Title quoted one two three');
+  });
+
+  it('should strip html tags', () => {
+    expect(toPlainText('a <span class="x">tagged</span> word')).toBe(
+      'a tagged word',
+    );
+  });
+
+  it('should collapse whitespace', () => {
+    expect(toPlainText('a\n\n\nb   c')).toBe('a b c');
+  });
+});
+
+describe('buildExcerpt', () => {
+  const long = `Deployment covers a lot of ground. ${'Filler sentence about unrelated topics. '.repeat(8)}The TURSO_DB_URL value configures the remote database connection. ${'More trailing filler here. '.repeat(8)}`;
+
+  it('should return short content unchanged and without ellipses', () => {
+    const excerpt = buildExcerpt('A short article body.', 'short');
+    expect(excerpt).toBe('A short article body.');
+    expect(excerpt).not.toContain('…');
+  });
+
+  it('should center the window on the first query term', () => {
+    const excerpt = buildExcerpt(long, 'TURSO_DB_URL');
+    expect(excerpt).toContain('TURSO_DB_URL');
+  });
+
+  it('should stay near the requested length', () => {
+    const excerpt = buildExcerpt(long, 'TURSO_DB_URL', 160);
+    expect(excerpt.length).toBeLessThanOrEqual(162 + 2);
+  });
+
+  it('should fall back to the opening prose when no term matches', () => {
+    const excerpt = buildExcerpt(long, 'nonexistentterm');
+    expect(excerpt.startsWith('Deployment covers a lot of ground.')).toBe(true);
+    expect(excerpt).not.toContain('…Deployment');
+  });
+
+  it('should mark a truncated tail with an ellipsis', () => {
+    expect(buildExcerpt(long, 'nonexistentterm').endsWith('…')).toBe(true);
+  });
+
+  it('should mark a truncated head with an ellipsis', () => {
+    expect(buildExcerpt(long, 'TURSO_DB_URL').startsWith('…')).toBe(true);
+  });
+
+  it('should use the earliest of several query terms', () => {
+    const excerpt = buildExcerpt(long, 'TURSO_DB_URL Deployment');
+    expect(excerpt.startsWith('Deployment')).toBe(true);
+  });
+
+  it('should ignore one-character query terms when centering', () => {
+    const excerpt = buildExcerpt(long, 'a');
+    expect(excerpt.startsWith('Deployment')).toBe(true);
+  });
+
+  it('should match query terms case-insensitively', () => {
+    expect(buildExcerpt(long, 'turso_db_url')).toContain('TURSO_DB_URL');
+  });
+
+  it('should strip markdown before excerpting', () => {
+    const excerpt = buildExcerpt('# Title\n\nSome **bold** prose.', 'prose');
+    expect(excerpt).toBe('Title Some bold prose.');
+  });
+
+  it('should handle empty content and empty query', () => {
+    expect(buildExcerpt('', 'anything')).toBe('');
+    expect(buildExcerpt('Some prose here.', '')).toBe('Some prose here.');
+  });
+
+  it('should tolerate null content and null query from the database', () => {
+    // libsql can hand back a null column even though the type says string.
+    expect(buildExcerpt(null as unknown as string, 'q')).toBe('');
+    expect(buildExcerpt('Some prose here.', null as unknown as string)).toBe(
+      'Some prose here.',
+    );
+  });
+
+  it('should fall back to the opening when the query is null on long text', () => {
+    const excerpt = buildExcerpt(long, null as unknown as string);
+    expect(excerpt.startsWith('Deployment covers a lot of ground.')).toBe(true);
+  });
+
+  it('should not trim the tail when the window has no late word break', () => {
+    const excerpt = buildExcerpt(`start ${'y'.repeat(500)}`, 'start', 100);
+    expect(excerpt).toContain('start');
+    expect(excerpt.endsWith('…')).toBe(true);
+  });
+
+  it('should handle text only slightly longer than the window', () => {
+    const text = `${'word '.repeat(33)}end`;
+    const excerpt = buildExcerpt(text, 'end', 160);
+    expect(excerpt.length).toBeGreaterThan(0);
+    expect(excerpt).toContain('end');
+  });
+
+  it('should handle a long unbroken run with no spaces to snap to', () => {
+    const excerpt = buildExcerpt(`${'x'.repeat(400)}TARGET`, 'TARGET', 100);
+    expect(excerpt).toContain('x');
+    expect(excerpt.length).toBeLessThanOrEqual(104);
+  });
+
+  it('should not split a word at the start of the window', () => {
+    const excerpt = buildExcerpt(long, 'TURSO_DB_URL');
+    const firstWord = excerpt.replace(/^…/, '').split(' ')[0];
+    expect(long).toContain(firstWord);
+  });
+});

--- a/src/lib/excerpt.ts
+++ b/src/lib/excerpt.ts
@@ -1,0 +1,94 @@
+/**
+ * Builds short plain-text excerpts from article markdown for search results.
+ */
+
+const DEFAULT_EXCERPT_LENGTH = 160;
+
+/** Terms shorter than this are too noisy to center an excerpt on. */
+const MIN_TERM_LENGTH = 2;
+
+/**
+ * Strips markdown syntax down to readable prose.
+ *
+ * Emphasis markers are matched as pairs rather than deleted character by
+ * character, so identifiers keep their underscores: a blanket `[_*~]` strip
+ * turns `vector_distance_cos` into `vectordistancecos`.
+ */
+export function toPlainText(markdown: string): string {
+  return (
+    markdown
+      // Fenced code carries no useful prose and its punctuation reads badly.
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/~~~[\s\S]*?~~~/g, ' ')
+      .replace(/`([^`]*)`/g, '$1')
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+      .replace(/^\s{0,3}>\s?/gm, '')
+      .replace(/^\s{0,3}[-*+]\s+/gm, '')
+      .replace(/^\s{0,3}\d+[.)]\s+/gm, '')
+      .replace(/^\s{0,3}([-*_])\s*(?:\1\s*){2,}$/gm, ' ')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/~~([^~]+)~~/g, '$1')
+      // Underscore emphasis only at word boundaries, never mid-identifier.
+      .replace(/(^|[\s(])__([^_]+)__(?=[\s).,;:!?]|$)/g, '$1$2')
+      .replace(/(^|[\s(])_([^_]+)_(?=[\s).,;:!?]|$)/g, '$1$2')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
+/** Index of the earliest query term in the text, or -1 when none appear. */
+function findFirstTermIndex(text: string, query: string): number {
+  const haystack = text.toLowerCase();
+  let earliest = -1;
+
+  for (const term of query.toLowerCase().split(/\s+/)) {
+    if (term.length < MIN_TERM_LENGTH) continue;
+    const index = haystack.indexOf(term);
+    if (index !== -1 && (earliest === -1 || index < earliest)) {
+      earliest = index;
+    }
+  }
+
+  return earliest;
+}
+
+/**
+ * A plain-text window of `content`, centered on the first matching query term
+ * and falling back to the opening prose. Semantic search can match an article
+ * whose text never contains the query, which is why the fallback exists.
+ */
+export function buildExcerpt(
+  content: string,
+  query: string,
+  maxLength: number = DEFAULT_EXCERPT_LENGTH,
+): string {
+  const text = toPlainText(content ?? '');
+  if (text.length <= maxLength) return text;
+
+  const match = findFirstTermIndex(text, query ?? '');
+  // Sit the match about a third in, so there is leading context but the term
+  // is still visible without reading to the end.
+  let start = match === -1 ? 0 : Math.max(0, match - Math.floor(maxLength / 3));
+
+  if (start > 0) {
+    // Advance to a word boundary so the excerpt does not open mid-word.
+    const nextSpace = text.indexOf(' ', start);
+    if (nextSpace !== -1 && nextSpace - start <= 20) start = nextSpace + 1;
+  }
+
+  let slice = text.slice(start, start + maxLength);
+  const reachedEnd = start + maxLength >= text.length;
+
+  if (!reachedEnd) {
+    const lastSpace = slice.lastIndexOf(' ');
+    if (lastSpace > maxLength * 0.6) slice = slice.slice(0, lastSpace);
+  }
+
+  slice = slice.trim();
+
+  return `${start > 0 ? '…' : ''}${slice}${start + slice.length < text.length ? '…' : ''}`;
+}

--- a/src/lib/searchCache.test.ts
+++ b/src/lib/searchCache.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSearchCache, searchCacheKey } from './searchCache';
+
+describe('searchCacheKey', () => {
+  it('should normalize case and surrounding whitespace', () => {
+    expect(searchCacheKey('  Deploy  ', 10)).toBe(searchCacheKey('deploy', 10));
+  });
+
+  it('should collapse internal whitespace', () => {
+    expect(searchCacheKey('getting   started', 10)).toBe(
+      searchCacheKey('getting started', 10),
+    );
+  });
+
+  it('should treat different limits as different keys', () => {
+    expect(searchCacheKey('deploy', 10)).not.toBe(searchCacheKey('deploy', 5));
+  });
+
+  it('should keep distinct queries distinct', () => {
+    expect(searchCacheKey('deploy', 10)).not.toBe(searchCacheKey('search', 10));
+  });
+});
+
+describe('createSearchCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should apply sane defaults when constructed with no options', () => {
+    const cache = createSearchCache<number>();
+
+    cache.set('k', 1);
+
+    expect(cache.enabled).toBe(true);
+    expect(cache.get('k')).toBe(1);
+  });
+
+  it('should return a stored value', () => {
+    const cache = createSearchCache<string[]>({ ttlMs: 1000 });
+    cache.set('k', ['a']);
+    expect(cache.get('k')).toEqual(['a']);
+  });
+
+  it('should miss on an unknown key', () => {
+    const cache = createSearchCache<string[]>({ ttlMs: 1000 });
+    expect(cache.get('nope')).toBeUndefined();
+  });
+
+  it('should expire an entry once its TTL passes', () => {
+    const cache = createSearchCache<string[]>({ ttlMs: 1000 });
+    cache.set('k', ['a']);
+
+    vi.advanceTimersByTime(999);
+    expect(cache.get('k')).toEqual(['a']);
+
+    vi.advanceTimersByTime(2);
+    expect(cache.get('k')).toBeUndefined();
+  });
+
+  it('should be disabled when the TTL is zero', () => {
+    const cache = createSearchCache<string[]>({ ttlMs: 0 });
+    cache.set('k', ['a']);
+
+    expect(cache.enabled).toBe(false);
+    expect(cache.get('k')).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it('should be disabled when the TTL is negative', () => {
+    expect(createSearchCache({ ttlMs: -1 }).enabled).toBe(false);
+  });
+
+  it('should never exceed maxEntries', () => {
+    const cache = createSearchCache<number>({ ttlMs: 10_000, maxEntries: 3 });
+
+    for (let i = 0; i < 10; i++) {
+      cache.set(`k${i}`, i);
+    }
+
+    expect(cache.size).toBe(3);
+  });
+
+  it('should evict the entry closest to expiry when full', () => {
+    const cache = createSearchCache<number>({ ttlMs: 10_000, maxEntries: 2 });
+
+    cache.set('oldest', 1);
+    vi.advanceTimersByTime(10);
+    cache.set('newer', 2);
+    vi.advanceTimersByTime(10);
+    cache.set('newest', 3);
+
+    expect(cache.get('oldest')).toBeUndefined();
+    expect(cache.get('newer')).toBe(2);
+    expect(cache.get('newest')).toBe(3);
+  });
+
+  it('should refresh an existing key rather than grow', () => {
+    const cache = createSearchCache<number>({ ttlMs: 1000, maxEntries: 5 });
+
+    cache.set('k', 1);
+    vi.advanceTimersByTime(500);
+    cache.set('k', 2);
+
+    expect(cache.size).toBe(1);
+    expect(cache.get('k')).toBe(2);
+
+    // The refreshed entry carries a full TTL from the second write.
+    vi.advanceTimersByTime(600);
+    expect(cache.get('k')).toBe(2);
+  });
+
+  it('should sweep expired entries without an interval timer', () => {
+    const cache = createSearchCache<number>({
+      ttlMs: 100,
+      cleanupIntervalMs: 50,
+    });
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    expect(cache.size).toBe(2);
+
+    vi.advanceTimersByTime(200);
+    cache.get('anything');
+
+    expect(cache.size).toBe(0);
+  });
+
+  it('should drop every entry on clear', () => {
+    const cache = createSearchCache<number>({ ttlMs: 10_000 });
+
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.clear();
+
+    expect(cache.size).toBe(0);
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('should keep working after a clear', () => {
+    const cache = createSearchCache<number>({ ttlMs: 10_000 });
+
+    cache.set('a', 1);
+    cache.clear();
+    cache.set('b', 2);
+
+    expect(cache.get('b')).toBe(2);
+  });
+
+  it('should keep separate instances isolated', () => {
+    const a = createSearchCache<number>({ ttlMs: 1000 });
+    const b = createSearchCache<number>({ ttlMs: 1000 });
+
+    a.set('k', 1);
+
+    expect(b.get('k')).toBeUndefined();
+  });
+});

--- a/src/lib/searchCache.ts
+++ b/src/lib/searchCache.ts
@@ -1,0 +1,132 @@
+/**
+ * Bounded in-memory search result cache.
+ *
+ * The index only changes when content is reindexed and the server restarts, so
+ * a per-process cache cannot serve stale results under the current deployment
+ * model. Multi-instance deployments each keep their own; that is fine, since a
+ * miss only costs what every request costs today.
+ */
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 500;
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export interface SearchCacheOptions {
+  /** Entry lifetime. Zero or negative disables the cache entirely. */
+  ttlMs?: number;
+  maxEntries?: number;
+  cleanupIntervalMs?: number;
+}
+
+export interface SearchCache<T> {
+  get: (key: string) => T | undefined;
+  set: (key: string, value: T) => void;
+  /** Drop every entry. Used when a process wants a clean slate. */
+  clear: () => void;
+  readonly size: number;
+  readonly enabled: boolean;
+}
+
+/**
+ * Cache key for a query. Case and surrounding whitespace are normalized away,
+ * so "Deploy" and "deploy " share an entry. Their embeddings would differ
+ * slightly and could rank results differently; collapsing them is a deliberate
+ * trade of exactness for a lower call count.
+ */
+export function searchCacheKey(query: string, limit: number): string {
+  return `${limit}:${query.trim().toLowerCase().replace(/\s+/g, ' ')}`;
+}
+
+/**
+ * Create an isolated cache. Expired entries are swept opportunistically on
+ * reads rather than on a timer, so the cache never keeps a process alive.
+ */
+export function createSearchCache<T>(
+  options: SearchCacheOptions = {},
+): SearchCache<T> {
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const maxEntries =
+    options.maxEntries && options.maxEntries > 0
+      ? options.maxEntries
+      : DEFAULT_MAX_ENTRIES;
+  const cleanupIntervalMs =
+    options.cleanupIntervalMs && options.cleanupIntervalMs > 0
+      ? options.cleanupIntervalMs
+      : CLEANUP_INTERVAL_MS;
+
+  const enabled = ttlMs > 0;
+  const store = new Map<string, CacheEntry<T>>();
+  let nextCleanupTime = 0;
+
+  function cleanupExpiredEntries(now: number): void {
+    for (const [key, entry] of store.entries()) {
+      if (now >= entry.expiresAt) store.delete(key);
+    }
+  }
+
+  function evictEarliestExpiry(): void {
+    let candidate: string | undefined;
+    let earliest = Number.POSITIVE_INFINITY;
+
+    for (const [key, entry] of store.entries()) {
+      if (entry.expiresAt < earliest) {
+        candidate = key;
+        earliest = entry.expiresAt;
+      }
+    }
+
+    if (candidate !== undefined) store.delete(candidate);
+  }
+
+  return {
+    get(key) {
+      if (!enabled) return undefined;
+
+      const now = Date.now();
+      if (now >= nextCleanupTime) {
+        cleanupExpiredEntries(now);
+        nextCleanupTime = now + cleanupIntervalMs;
+      }
+
+      const entry = store.get(key);
+      if (!entry) return undefined;
+
+      if (now >= entry.expiresAt) {
+        store.delete(key);
+        return undefined;
+      }
+
+      return entry.value;
+    },
+
+    set(key, value) {
+      if (!enabled) return;
+
+      // Refresh in place so a repeated query does not evict a live neighbour.
+      store.delete(key);
+      while (store.size >= maxEntries) {
+        evictEarliestExpiry();
+      }
+
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+    },
+
+    clear() {
+      store.clear();
+      nextCleanupTime = 0;
+    },
+
+    get size() {
+      return store.size;
+    },
+
+    get enabled() {
+      return enabled;
+    },
+  };
+}

--- a/src/pages/api/search.json.test.ts
+++ b/src/pages/api/search.json.test.ts
@@ -1,7 +1,7 @@
 import type { SearchResult } from '@logan/libsql-search';
 import type { APIContext } from 'astro';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GET, POST } from './search.json';
+import { GET, POST, searchCache } from './search.json';
 
 // Mock dependencies
 vi.mock('@logan/libsql-search', () => ({
@@ -26,6 +26,9 @@ function createMockContext(
 describe('Search API Route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The result cache is process-wide, so a hit in one test would otherwise
+    // satisfy the next one without ever reaching the mocked search.
+    searchCache.clear();
     // Every search path resolves Workers AI credentials before querying.
     vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', 'test-account-id');
     vi.stubEnv('CLOUDFLARE_API_TOKEN', 'test-api-token');
@@ -62,9 +65,146 @@ describe('Search API Route', () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.results).toEqual(mockResults);
+      expect(data.results).toEqual([
+        {
+          id: 1,
+          title: 'Test Article',
+          slug: 'test',
+          folder: 'docs',
+          tags: ['test'],
+          distance: 0.5,
+          excerpt: 'Test content',
+        },
+      ]);
       expect(data.count).toBe(1);
       expect(data.query).toBe('test query');
+    });
+
+    it('should not ship article content to the client', async () => {
+      vi.mocked(search).mockResolvedValueOnce([
+        {
+          id: 1,
+          title: 'Test Article',
+          slug: 'test',
+          folder: 'docs',
+          tags: ['test'],
+          distance: 0.5,
+          content: 'A'.repeat(50_000),
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ]);
+
+      const response = await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'payload check' }),
+          }),
+          '192.0.2.14',
+        ),
+      );
+      const body = await response.text();
+
+      expect(body).not.toContain('A'.repeat(1000));
+      expect(JSON.parse(body).results[0]).not.toHaveProperty('content');
+    });
+
+    it('should serve a repeated query from cache without re-embedding', async () => {
+      vi.mocked(search).mockResolvedValue([]);
+
+      const send = () =>
+        POST(
+          createMockContext(
+            new Request('http://localhost/api/search.json', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ query: 'cached query', limit: 5 }),
+            }),
+            '192.0.2.10',
+          ),
+        );
+
+      const first = await send();
+      const second = await send();
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(await second.json()).toEqual(await first.json());
+      // The billed embedding call happens inside search(); one call for two
+      // requests is the whole point of the cache.
+      expect(search).toHaveBeenCalledTimes(1);
+    });
+
+    it('should treat a different limit as a separate cache entry', async () => {
+      vi.mocked(search).mockResolvedValue([]);
+
+      const send = (limit: number) =>
+        POST(
+          createMockContext(
+            new Request('http://localhost/api/search.json', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ query: 'same query', limit }),
+            }),
+            '192.0.2.11',
+          ),
+        );
+
+      await send(5);
+      await send(10);
+
+      expect(search).toHaveBeenCalledTimes(2);
+    });
+
+    it('should share a cache entry across query casing and padding', async () => {
+      vi.mocked(search).mockResolvedValue([]);
+
+      const send = (query: string) =>
+        POST(
+          createMockContext(
+            new Request('http://localhost/api/search.json', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ query, limit: 5 }),
+            }),
+            '192.0.2.12',
+          ),
+        );
+
+      await send('Deploy');
+      await send('  deploy  ');
+
+      expect(search).toHaveBeenCalledTimes(1);
+    });
+
+    it('should build the excerpt around the query term', async () => {
+      vi.mocked(search).mockResolvedValueOnce([
+        {
+          id: 1,
+          title: 'Deployment',
+          slug: 'deploy',
+          folder: 'docs',
+          tags: [],
+          distance: 0.1,
+          content: `${'Filler prose about nothing. '.repeat(20)}The TURSO_DB_URL setting names the database. ${'Trailing filler. '.repeat(20)}`,
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ]);
+
+      const response = await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'TURSO_DB_URL' }),
+          }),
+          '192.0.2.13',
+        ),
+      );
+      const data = await response.json();
+
+      expect(data.results[0].excerpt).toContain('TURSO_DB_URL');
     });
 
     it('should return 400 for missing query', async () => {
@@ -286,7 +426,10 @@ describe('Search API Route', () => {
             'Content-Type': 'application/json',
             'x-forwarded-for': `203.0.113.${index + 1}`,
           },
-          body: JSON.stringify({ query: 'test query' }),
+          // Unique per iteration: identical queries would be served from the
+          // result cache and never reach the mocked search, which is what this
+          // test counts to prove the limiter let them through.
+          body: JSON.stringify({ query: `test query ${index}` }),
         });
 
         response = await POST(createMockContext(request, '198.51.100.100'));
@@ -308,7 +451,9 @@ describe('Search API Route', () => {
             'Content-Type': 'application/json',
             'x-real-ip': '203.0.113.200',
           },
-          body: JSON.stringify({ query: 'test query' }),
+          // Unique per iteration so the result cache does not absorb requests
+          // this test counts to prove the limiter let them through.
+          body: JSON.stringify({ query: `test query ${index}` }),
         });
 
         response = await POST(

--- a/src/pages/api/search.json.ts
+++ b/src/pages/api/search.json.ts
@@ -7,6 +7,8 @@ import { search } from '@logan/libsql-search';
 import type { APIRoute } from 'astro';
 import { logger } from 'logan-logger';
 import { env } from '@/lib/env';
+import { buildExcerpt } from '@/lib/excerpt';
+import { createSearchCache, searchCacheKey } from '@/lib/searchCache';
 import {
   getEmbeddingOptions,
   SEARCH_EMBEDDING_TIMEOUT_MS,
@@ -17,6 +19,31 @@ import { isValidSearchQuery } from '@/lib/validation';
 import { checkRateLimit, createRateLimitHeaders } from '@/middleware/rateLimit';
 
 export const prerender = false;
+
+/**
+ * Result shape sent to the client. The library's SearchResult carries the full
+ * article body, which the UI never renders; shipping ten of those per debounced
+ * keystroke is the payload this replaces.
+ */
+export interface SearchResultPayload {
+  id: number;
+  slug: string;
+  title: string;
+  folder: string;
+  tags: string[];
+  distance: number;
+  excerpt: string;
+}
+
+/**
+ * Process-wide cache of trimmed results. Caching after the trim keeps article
+ * bodies out of memory, and the lookup happens before the Workers AI call so a
+ * hit skips the billed request entirely.
+ */
+export const searchCache = createSearchCache<SearchResultPayload[]>({
+  ttlMs: env.searchCacheTtlMs,
+  maxEntries: env.searchCacheMaxEntries,
+});
 
 /**
  * Environment configuration for validateOrigin
@@ -219,10 +246,24 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
     }
     const sanitizedLimit = Math.min(Math.max(1, numericLimit), 20);
 
+    const cacheKey = searchCacheKey(normalizedQuery, sanitizedLimit);
+    const cached = searchCache.get(cacheKey);
+
+    if (cached) {
+      return new Response(
+        JSON.stringify({
+          results: cached,
+          count: cached.length,
+          query: normalizedQuery,
+        }),
+        { status: 200, headers: rateLimitHeaders },
+      );
+    }
+
     const client = getTursoClient();
 
     // Perform vector search using centralized env config
-    const results = await search({
+    const matches = await search({
       client,
       query: normalizedQuery,
       limit: sanitizedLimit,
@@ -233,6 +274,18 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
         signal: request.signal,
       }),
     });
+
+    const results: SearchResultPayload[] = matches.map((match) => ({
+      id: match.id,
+      slug: match.slug,
+      title: match.title,
+      folder: match.folder,
+      tags: match.tags,
+      distance: match.distance,
+      excerpt: buildExcerpt(match.content, normalizedQuery),
+    }));
+
+    searchCache.set(cacheKey, results);
 
     return new Response(
       JSON.stringify({


### PR DESCRIPTION
## Summary

Closes #103 and #104.

- The search API passed the library's `SearchResult` straight through, including the full article body, so a ten-result response shipped ten complete documents on every debounced keystroke while the UI rendered only the title and tags. Responses now carry `id`, `slug`, `title`, `folder`, `tags`, `distance`, and a short excerpt instead.
- A bounded per-process cache now sits in front of the embedding call, keyed by normalized query and limit, so a repeated query costs nothing upstream on the billed Cloudflare Workers AI call.

## Changes

### Excerpts
- **src/lib/excerpt.ts**: New module extracting a ~160 character plain-text window centered on the first query term, falling back to the opening prose when semantic search matches an article whose text never contains the query term. Emphasis markers (`**`, `*`, `_`) are matched as pairs rather than stripped character by character, since a blanket strip turns `vector_distance_cos` into `vectordistancecos` and this repo's own content carries 31 such identifiers.
- **src/pages/api/search.json.ts**: Trims the library's `SearchResult` down to `id`, `slug`, `title`, `folder`, `tags`, `distance`, and `excerpt` before responding; article bodies no longer leave the server.
- **src/components/Search.tsx**: Renders the new `excerpt` field in result cards.

### Caching
- **src/lib/searchCache.ts**: New bounded per-process cache keyed by normalized query and limit. Follows the rate limiter's existing pattern of sweeping expired entries on read rather than on an interval that would keep the process alive, and stores only the trimmed results so article bodies never sit in memory.
- **src/lib/env.ts**: Adds `SEARCH_CACHE_TTL_SECONDS` and `SEARCH_CACHE_MAX_ENTRIES` env parsing; a TTL of `0` disables the cache.
- **src/pages/api/search.json.ts**: Checks the cache before calling `search()` and populates it after.
- **.env.example**: Documents the two new cache env vars.

### Documentation
- **docs/REFERENCE.md**: Documents the trimmed response shape and the new cache env vars.
- **docs/SECURITY.md**: Documents the cache's staleness/credential-revocation tradeoff (see Notes for review).

### Tests
- **src/lib/excerpt.test.ts**: New, covers centering, fallback, and paired-emphasis-marker handling.
- **src/lib/searchCache.test.ts**: New, covers TTL expiry, max-entries eviction, key normalization, and the disabled (`TTL=0`) path.
- **src/pages/api/search.json.test.ts**: Updated for the trimmed response shape and cache behavior; see Notes for review.

## Verification
- 273 tests across 17 files pass; `pnpm lint` and `pnpm exec tsc --noEmit` clean
- New modules: `excerpt.ts` at 100% statements/branches/functions/lines; `searchCache.ts` at 100% statements/functions/lines (one unreachable defensive branch, matching the same guard already in `rateLimit.ts`)
- Payload measured directly against the indexed content in `local.db`: 21386 → 1047 bytes for ten results, 95.1% smaller
- Cache verified by asserting the mocked `search` (which wraps the billed embedding call) runs once across two identical requests, twice across two different limits, and once across `Deploy` vs `  deploy  `
- `pnpm build` succeeds

## Notes for review
1. Existing search API tests needed updating: two rate-limit tests fired 21 identical queries and asserted `search` ran 20 times, which the cache now absorbs. Their queries are unique per iteration so they still measure the limiter rather than the cache.
2. The cache is a process-wide singleton, so it is exported and cleared in `beforeEach`; without that a hit in one test satisfies the next.
3. While a query is cached, results are served without contacting Cloudflare, so revoked credentials surface only when the entry expires rather than on the next request. Documented in `docs/SECURITY.md`.

Closes #103
Closes #104