### PR TITLE
feat(search): fuse FTS5 keyword results with vector search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,7 @@ CLOUDFLARE_API_TOKEN=your-api-token
 # Set the TTL to 0 to disable caching.
 # SEARCH_CACHE_TTL_SECONDS=300
 # SEARCH_CACHE_MAX_ENTRIES=500
+
+# Hybrid retrieval: FTS5 keyword results fused with vector results.
+# Set to false to fall back to vector-only search.
+# SEARCH_HYBRID_ENABLED=true

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -79,6 +79,10 @@ pnpm index
 The legacy `articles` and `articles_local_384` tables can be retired separately
 once the new index is validated.
 
+Hybrid search adds a keyword index, `articles_cf_bgem3_1024_fts`. Run
+`pnpm db:init` to create it and `pnpm index` to populate it. Until both have
+run, search logs a warning and returns vector-only results.
+
 ## Containers
 
 Two Dockerfiles are provided. Both index content during the build, and indexing

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -80,8 +80,20 @@ The legacy `articles` and `articles_local_384` tables can be retired separately
 once the new index is validated.
 
 Hybrid search adds a keyword index, `articles_cf_bgem3_1024_fts`. Run
-`pnpm db:init` to create it and `pnpm index` to populate it. Until both have
-run, search logs a warning and returns vector-only results.
+`pnpm db:init` to create it and `pnpm index` to populate it. **Both are
+required**, and only the first missing step announces itself:
+
+- Neither has run: the keyword query errors, search logs a warning and returns
+  vector-only results.
+- `db:init` ran but `index` did not: the index exists and is empty, so the query
+  succeeds with zero rows. Search silently returns vector-only results with no
+  warning, which looks like a ranking regression rather than a missed step.
+
+After upgrading, confirm the index is populated rather than assuming it:
+
+```sql
+SELECT count(*) FROM articles_cf_bgem3_1024_fts;
+```
 
 ## Containers
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -39,10 +39,36 @@ semantic-docs/
 - local development database: `file:local.db` when Turso credentials are absent
 - result cache: 500 entries, 5 minute TTL, per process
   (`SEARCH_CACHE_TTL_SECONDS`, `SEARCH_CACHE_MAX_ENTRIES`; `0` disables)
+- keyword index: `articles_cf_bgem3_1024_fts` (FTS5 over title, content, tags)
+- retrieval: hybrid, keyword and vector fused by reciprocal rank fusion
+  (`SEARCH_HYBRID_ENABLED=false` falls back to vector only)
 
 Those values are defined in [searchConfig.ts](../src/lib/searchConfig.ts).
 
+### Hybrid Retrieval
+
+Each query runs an FTS5 keyword search and a vector search concurrently, then
+merges the two ranked lists by reciprocal rank fusion. Keyword retrieval covers
+what dense embeddings handle worst — exact identifiers, error strings, flag
+names — while vector retrieval still answers conversational queries.
+
+Every query term is emitted as a quoted FTS5 phrase. That neutralizes the query
+language (a bare `AND`, `*` or unbalanced quote would otherwise be parsed as
+syntax) and makes identifier lookup precise: `"TURSO_DB_URL"` matches only where
+those tokens are adjacent.
+
+Each retriever returns three times the requested limit before fusion, since
+fusion can only reorder what it is given. Exact score ties are broken in favour
+of the keyword list.
+
+The keyword index is created by `pnpm db:init` and rebuilt by `pnpm index`. If
+it is missing, search logs a warning and returns vector-only results rather than
+failing — so upgrading code before re-running `db:init` degrades rather than
+breaks.
+
 `/api/search.json` returns `id, slug, title, folder, tags, distance, excerpt`.
+`distance` is null for a document found only by keyword, since bm25 relevance
+and vector distance are unrelated scales.
 The excerpt is a ~160 character plain-text window built by
 [excerpt.ts](../src/lib/excerpt.ts), centered on the first query term where the
 article contains one. Article bodies are never sent to the client.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -58,8 +58,16 @@ syntax) and makes identifier lookup precise: `"TURSO_DB_URL"` matches only where
 those tokens are adjacent.
 
 Each retriever returns three times the requested limit before fusion, since
-fusion can only reorder what it is given. Exact score ties are broken in favour
-of the keyword list.
+fusion can only reorder what it is given.
+
+The two lists are weighted rather than tie-broken: each contributes
+`weight / (k + rank)`, with vector at 1 and keyword at 0.85. Equal weights would
+make a rank-1 hit in either list score identically, and resolving that by
+argument order hands every disagreement to bm25 — deciding the top result for
+conversational queries, not just the exact-match ones keyword retrieval exists
+to serve. Unequal weights make that tie unreachable, and a keyword hit still
+wins when both retrievers agree on it. The weights are a tuning knob in
+`searchConfig.ts`.
 
 The keyword index is created by `pnpm db:init` and rebuilt by `pnpm index`, and
 is joined on `slug` rather than rowid because the indexer reinserts every

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -61,14 +61,17 @@ Each retriever returns three times the requested limit before fusion, since
 fusion can only reorder what it is given. Exact score ties are broken in favour
 of the keyword list.
 
-The keyword index is created by `pnpm db:init` and rebuilt by `pnpm index`. If
-it is missing, search logs a warning and returns vector-only results rather than
-failing — so upgrading code before re-running `db:init` degrades rather than
-breaks.
+The keyword index is created by `pnpm db:init` and rebuilt by `pnpm index`, and
+is joined on `slug` rather than rowid because the indexer reinserts every
+article with a new id. A missing index logs a warning and yields vector-only
+results; an index that exists but was never populated returns zero rows
+silently, so verify both steps ran after an upgrade.
 
 `/api/search.json` returns `id, slug, title, folder, tags, distance, excerpt`.
-`distance` is null for a document found only by keyword, since bm25 relevance
-and vector distance are unrelated scales.
+`distance` is null for any document the keyword retriever returned, not only
+those it alone found: fusion keeps the first-seen row and keyword results merge
+first. bm25 relevance and vector distance are unrelated scales, so there is no
+single comparable score to report.
 The excerpt is a ~160 character plain-text window built by
 [excerpt.ts](../src/lib/excerpt.ts), centered on the first query term where the
 article contains one. Article bodies are never sent to the client.

--- a/scripts/index-content-runner.test.ts
+++ b/scripts/index-content-runner.test.ts
@@ -76,4 +76,54 @@ describe('runContentIndexing', () => {
       indexingError,
     );
   });
+  it('rebuilds the keyword index after the rows are written', async () => {
+    const order: string[] = [];
+    const logger = createLogger();
+    const operations: IndexingOperations = {
+      createTable: vi.fn().mockResolvedValue(undefined),
+      indexContent: vi.fn(async () => {
+        order.push('indexContent');
+        return { success: 1, total: 1, failed: 0 };
+      }),
+      rebuildKeywordIndex: vi.fn(async () => {
+        order.push('rebuildKeywordIndex');
+      }),
+    };
+
+    const exitCode = await runContentIndexing(operations, logger);
+
+    expect(exitCode).toBe(0);
+    // Order matters: a keyword index built first would describe rows a failed
+    // embedding run never wrote.
+    expect(order).toEqual(['indexContent', 'rebuildKeywordIndex']);
+    expect(logger.info).toHaveBeenCalledWith('Rebuilt keyword index');
+  });
+
+  it('skips the keyword rebuild when no operation is supplied', async () => {
+    const logger = createLogger();
+    const operations: IndexingOperations = {
+      createTable: vi.fn().mockResolvedValue(undefined),
+      indexContent: vi.fn().mockResolvedValue({
+        success: 1,
+        total: 1,
+        failed: 0,
+      }),
+    };
+
+    expect(await runContentIndexing(operations, logger)).toBe(0);
+    expect(logger.info).not.toHaveBeenCalledWith('Rebuilt keyword index');
+  });
+
+  it('does not rebuild the keyword index when indexing throws', async () => {
+    const logger = createLogger();
+    const rebuildKeywordIndex = vi.fn();
+    const operations: IndexingOperations = {
+      createTable: vi.fn().mockResolvedValue(undefined),
+      indexContent: vi.fn().mockRejectedValue(new Error('embedding failed')),
+      rebuildKeywordIndex,
+    };
+
+    expect(await runContentIndexing(operations, logger)).toBe(1);
+    expect(rebuildKeywordIndex).not.toHaveBeenCalled();
+  });
 });

--- a/scripts/index-content-runner.ts
+++ b/scripts/index-content-runner.ts
@@ -13,6 +13,8 @@ export type IndexProgress = (
 export interface IndexingOperations {
   createTable: () => Promise<unknown>;
   indexContent: (onProgress: IndexProgress) => Promise<IndexingResult>;
+  /** Repopulate the keyword index from the rows just written. */
+  rebuildKeywordIndex?: () => Promise<void>;
 }
 
 export interface IndexingLogger {
@@ -36,6 +38,13 @@ export async function runContentIndexing(
     const result = await operations.indexContent((current, total, file) => {
       logger.info(`[${current}/${total}] Indexing: ${file}`);
     });
+
+    // After the vector rows land, so a failed embedding run never leaves a
+    // keyword index describing content that is not in the articles table.
+    if (operations.rebuildKeywordIndex) {
+      await operations.rebuildKeywordIndex();
+      logger.info('Rebuilt keyword index');
+    }
 
     logger.info('Indexing complete!');
     logger.info(

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -48,12 +48,19 @@ const embeddingOptions = getEmbeddingOptions();
  */
 async function rebuildKeywordIndex(): Promise<void> {
   await client.execute(
-    `CREATE VIRTUAL TABLE IF NOT EXISTS "${SEARCH_FTS_TABLE_NAME}" USING fts5(title, content, tags)`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS "${SEARCH_FTS_TABLE_NAME}" USING fts5(slug UNINDEXED, title, content, tags)`,
   );
-  await client.execute(`DELETE FROM "${SEARCH_FTS_TABLE_NAME}"`);
-  await client.execute(
-    `INSERT INTO "${SEARCH_FTS_TABLE_NAME}"(rowid, title, content, tags)
-     SELECT id, title, content, tags FROM "${SEARCH_TABLE_NAME}"`,
+
+  // One transaction: a clear that commits without its refill would leave the
+  // keyword index empty, and an empty index returns rows cleanly rather than
+  // erroring, so nothing downstream would notice.
+  await client.batch(
+    [
+      `DELETE FROM "${SEARCH_FTS_TABLE_NAME}"`,
+      `INSERT INTO "${SEARCH_FTS_TABLE_NAME}"(slug, title, content, tags)
+       SELECT slug, title, content, tags FROM "${SEARCH_TABLE_NAME}"`,
+    ],
+    'write',
   );
 }
 

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -11,6 +11,7 @@ import { env } from '../src/lib/env';
 import {
   EMBEDDING_DIMENSIONS,
   getEmbeddingOptions,
+  SEARCH_FTS_TABLE_NAME,
   SEARCH_TABLE_NAME,
 } from '../src/lib/searchConfig';
 import { runContentIndexing } from './index-content-runner';
@@ -39,6 +40,23 @@ if (!env.hasCloudflareCredentials) {
 
 const embeddingOptions = getEmbeddingOptions();
 
+/**
+ * Rebuild the keyword index from the rows just written. A full rebuild rather
+ * than an incremental update, because the indexer clears the articles table on
+ * every run; this keeps the two halves of hybrid search in step without
+ * assuming anything about how the rows got there.
+ */
+async function rebuildKeywordIndex(): Promise<void> {
+  await client.execute(
+    `CREATE VIRTUAL TABLE IF NOT EXISTS "${SEARCH_FTS_TABLE_NAME}" USING fts5(title, content, tags)`,
+  );
+  await client.execute(`DELETE FROM "${SEARCH_FTS_TABLE_NAME}"`);
+  await client.execute(
+    `INSERT INTO "${SEARCH_FTS_TABLE_NAME}"(rowid, title, content, tags)
+     SELECT id, title, content, tags FROM "${SEARCH_TABLE_NAME}"`,
+  );
+}
+
 process.exitCode = await runContentIndexing(
   {
     createTable: () =>
@@ -51,6 +69,7 @@ process.exitCode = await runContentIndexing(
         embeddingOptions,
         onProgress,
       }),
+    rebuildKeywordIndex,
   },
   logger,
 );

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -9,6 +9,7 @@ import { createTable } from '@logan/libsql-search';
 import { logger } from 'logan-logger';
 import {
   EMBEDDING_DIMENSIONS,
+  SEARCH_FTS_TABLE_NAME,
   SEARCH_TABLE_NAME,
 } from '../src/lib/searchConfig';
 
@@ -33,6 +34,16 @@ try {
   logger.info(
     `Created ${SEARCH_TABLE_NAME} with ${EMBEDDING_DIMENSIONS}-dimension embeddings`,
   );
+
+  // Keyword half of hybrid search. Kept as its own table rather than an
+  // external-content one: the indexer clears and repopulates the articles
+  // table wholesale, and a standalone index is rebuilt from it in one step
+  // without depending on trigger support.
+  await client.execute(
+    `CREATE VIRTUAL TABLE IF NOT EXISTS "${SEARCH_FTS_TABLE_NAME}" USING fts5(title, content, tags)`,
+  );
+
+  logger.info(`Created ${SEARCH_FTS_TABLE_NAME} keyword index`);
 
   // Verify table exists
   const result = await client.execute({

--- a/scripts/init-db.ts
+++ b/scripts/init-db.ts
@@ -39,8 +39,12 @@ try {
   // external-content one: the indexer clears and repopulates the articles
   // table wholesale, and a standalone index is rebuilt from it in one step
   // without depending on trigger support.
+  // slug is carried UNINDEXED and joined on instead of rowid: the indexer
+  // clears and reinserts the articles table, and with AUTOINCREMENT every row
+  // gets a new id, so rowids captured here would join to nothing after the
+  // next reindex.
   await client.execute(
-    `CREATE VIRTUAL TABLE IF NOT EXISTS "${SEARCH_FTS_TABLE_NAME}" USING fts5(title, content, tags)`,
+    `CREATE VIRTUAL TABLE IF NOT EXISTS "${SEARCH_FTS_TABLE_NAME}" USING fts5(slug UNINDEXED, title, content, tags)`,
   );
 
   logger.info(`Created ${SEARCH_FTS_TABLE_NAME} keyword index`);

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -20,7 +20,7 @@ interface SearchResult {
   slug: string;
   folder: string;
   tags: string[];
-  distance: number;
+  distance: number | null;
   excerpt: string;
 }
 

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -132,3 +132,29 @@ describe('env getters', () => {
     expect(env.rateLimitMaxEntries).toBe(500);
   });
 });
+
+describe('hybridSearchEnabled', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('should default to enabled when unset', () => {
+    expect(env.hybridSearchEnabled).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', 'False', '0', 'off', 'OFF', '  false  '])(
+    'should treat %s as disabled',
+    (value) => {
+      vi.stubEnv('SEARCH_HYBRID_ENABLED', value);
+      expect(env.hybridSearchEnabled).toBe(false);
+    },
+  );
+
+  it.each(['true', 'TRUE', '1', 'yes', 'anything'])(
+    'should leave %s enabled',
+    (value) => {
+      vi.stubEnv('SEARCH_HYBRID_ENABLED', value);
+      expect(env.hybridSearchEnabled).toBe(true);
+    },
+  );
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -131,6 +131,11 @@ export const env = {
     return getPositiveInteger('SEARCH_CACHE_MAX_ENTRIES', 500);
   },
 
+  /** Whether keyword results are fused with vector results */
+  get hybridSearchEnabled(): boolean {
+    return getEnv('SEARCH_HYBRID_ENABLED') !== 'false';
+  },
+
   /**
    * Node environment (development, production, test)
    */

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -133,7 +133,9 @@ export const env = {
 
   /** Whether keyword results are fused with vector results */
   get hybridSearchEnabled(): boolean {
-    return getEnv('SEARCH_HYBRID_ENABLED') !== 'false';
+    const value = getEnv('SEARCH_HYBRID_ENABLED')?.trim().toLowerCase();
+    // A kill switch that silently ignores FALSE or 0 is worse than none.
+    return !(value === 'false' || value === '0' || value === 'off');
   },
 
   /**

--- a/src/lib/fusion.test.ts
+++ b/src/lib/fusion.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { reciprocalRankFusion } from './fusion';
+import { FUSION_WEIGHTS } from './searchConfig';
 
 const doc = (id: number, label = '') => ({ id, label });
 
+/** The production pairing: keyword list first, weighted below vector. */
+const W = [FUSION_WEIGHTS.keyword, FUSION_WEIGHTS.vector];
+
 describe('reciprocalRankFusion', () => {
   it('should return an empty list when given no lists', () => {
-    expect(reciprocalRankFusion([], 10)).toEqual([]);
+    expect(reciprocalRankFusion([], 10, W)).toEqual([]);
   });
 
   it('should pass a single list through in order', () => {
     const list = [doc(1), doc(2), doc(3)];
-    expect(reciprocalRankFusion([list], 10).map((d) => d.id)).toEqual([
+    expect(reciprocalRankFusion([list], 10, [1]).map((d) => d.id)).toEqual([
       1, 2, 3,
     ]);
   });
@@ -19,86 +23,92 @@ describe('reciprocalRankFusion', () => {
     const keyword = [doc(1), doc(2)];
     const vector = [doc(3), doc(1)];
 
-    // 1 scores in both lists; 2 and 3 score in one each.
-    expect(reciprocalRankFusion([keyword, vector], 3)[0].id).toBe(1);
+    expect(reciprocalRankFusion([keyword, vector], 3, W)[0].id).toBe(1);
   });
 
   it('should respect the limit', () => {
     const list = [doc(1), doc(2), doc(3), doc(4)];
-    expect(reciprocalRankFusion([list], 2)).toHaveLength(2);
+    expect(reciprocalRankFusion([list], 2, [1])).toHaveLength(2);
   });
 
   it('should treat a zero limit as an empty result', () => {
-    expect(reciprocalRankFusion([[doc(1)]], 0)).toEqual([]);
+    expect(reciprocalRankFusion([[doc(1)]], 0, [1])).toEqual([]);
   });
 
   it('should not return duplicates when a document appears in both lists', () => {
-    const fused = reciprocalRankFusion([[doc(1)], [doc(1)]], 10);
-    expect(fused).toHaveLength(1);
+    expect(reciprocalRankFusion([[doc(1)], [doc(1)]], 10, W)).toHaveLength(1);
   });
 
   it('should keep the object from the earlier list on a duplicate', () => {
     const fused = reciprocalRankFusion(
       [[doc(1, 'keyword')], [doc(1, 'vector')]],
       10,
+      W,
     );
     expect(fused[0].label).toBe('keyword');
   });
 
-  it('should let a top keyword hit outrank a mid-ranked vector hit', () => {
-    // The identifier lookup case: bm25 puts the exact match first while the
-    // embedding buries it.
-    const keyword = [doc(42)];
-    const vector = [doc(1), doc(2), doc(3), doc(4), doc(42)];
+  it('should give the top slot to the vector hit when each retriever ranks a different document first', () => {
+    // Previously an exact tie resolved by argument order, which handed every
+    // disagreement to bm25 — including on conversational queries.
+    const keyword = [doc(9)];
+    const vector = [doc(4)];
 
-    expect(reciprocalRankFusion([keyword, vector], 5)[0].id).toBe(42);
+    expect(
+      reciprocalRankFusion([keyword, vector], 10, W).map((d) => d.id),
+    ).toEqual([4, 9]);
   });
 
-  it('should break an exact tie in favour of the earlier list', () => {
-    // Each is rank 1 in its own list, so the scores are identical. The caller
-    // passes keyword results first precisely so they win this case.
-    const tied = reciprocalRankFusion([[doc(9)], [doc(4)]], 10).map(
-      (d) => d.id,
-    );
-    expect(tied).toEqual([9, 4]);
+  it('should let a keyword hit win on agreement rather than on list order', () => {
+    // Ranked first by bm25 and third by the embedding still beats a document
+    // only the embedding liked: agreement outweighs the weight difference.
+    const keyword = [doc(42)];
+    const vector = [doc(1), doc(2), doc(42)];
+
+    expect(reciprocalRankFusion([keyword, vector], 5, W)[0].id).toBe(42);
+  });
+
+  it('should not let weights alone override a large rank gap', () => {
+    const keyword = [doc(7)];
+    const vector = [doc(1), doc(2), doc(3), doc(4), doc(5), doc(7)];
+
+    const fused = reciprocalRankFusion([keyword, vector], 6, W);
+    expect(fused[0].id).toBe(7);
+    expect(fused[1].id).toBe(1);
+  });
+
+  it('should default a missing weight to 1', () => {
+    const fused = reciprocalRankFusion([[doc(1)], [doc(2)]], 10, [0.5]);
+    expect(fused.map((d) => d.id)).toEqual([2, 1]);
   });
 
   it('should order deterministically across identical calls', () => {
     const run = () =>
-      reciprocalRankFusion([[doc(5), doc(2)], [doc(7)]], 10).map((d) => d.id);
+      reciprocalRankFusion([[doc(5), doc(2)], [doc(7)]], 10, W).map(
+        (d) => d.id,
+      );
     expect(run()).toEqual(run());
   });
 
-  it('should prefer the earlier list over id when lists differ', () => {
-    const fused = reciprocalRankFusion([[doc(8)], [], [doc(3)]], 10);
-    expect(fused.map((d) => d.id)).toEqual([8, 3]);
-  });
-
-  it('should fall back to id when tied documents share a first list', () => {
-    // With k = 0 a rank-1 hit scores 1/2, so id 3 reaches the same total as
-    // id 5 while both were first seen in list 0.
-    const fused = reciprocalRankFusion(
-      [
-        [doc(5), doc(3)],
-        [doc(9), doc(3)],
-      ],
-      10,
-      0,
-    );
-
-    expect(fused.slice(0, 2).map((d) => d.id)).toEqual([3, 5]);
+  it('should fall back to id on an exact tie', () => {
+    // Reachable only with equal weights, which production never passes.
+    const fused = reciprocalRankFusion([[doc(9)], [doc(4)]], 10, [1, 1]);
+    expect(fused.map((d) => d.id)).toEqual([4, 9]);
   });
 
   it('should ignore an empty list among populated ones', () => {
     expect(
-      reciprocalRankFusion([[], [doc(1), doc(2)]], 10).map((d) => d.id),
+      reciprocalRankFusion([[], [doc(1), doc(2)]], 10, W).map((d) => d.id),
     ).toEqual([1, 2]);
   });
 
   it('should apply the k constant when supplied', () => {
-    // A smaller k sharpens the advantage of rank 1 over rank 2.
-    const list = [doc(1), doc(2)];
-    const sharp = reciprocalRankFusion([list], 10, 1);
-    expect(sharp.map((d) => d.id)).toEqual([1, 2]);
+    const fused = reciprocalRankFusion([[doc(1), doc(2)]], 10, [1], 1);
+    expect(fused.map((d) => d.id)).toEqual([1, 2]);
+  });
+
+  it('should keep the configured weights distinct so ties cannot arise', () => {
+    expect(FUSION_WEIGHTS.keyword).not.toBe(FUSION_WEIGHTS.vector);
+    expect(FUSION_WEIGHTS.vector).toBeGreaterThan(FUSION_WEIGHTS.keyword);
   });
 });

--- a/src/lib/fusion.test.ts
+++ b/src/lib/fusion.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { reciprocalRankFusion } from './fusion';
+
+const doc = (id: number, label = '') => ({ id, label });
+
+describe('reciprocalRankFusion', () => {
+  it('should return an empty list when given no lists', () => {
+    expect(reciprocalRankFusion([], 10)).toEqual([]);
+  });
+
+  it('should pass a single list through in order', () => {
+    const list = [doc(1), doc(2), doc(3)];
+    expect(reciprocalRankFusion([list], 10).map((d) => d.id)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('should rank a document found by both retrievers above one found by either', () => {
+    const keyword = [doc(1), doc(2)];
+    const vector = [doc(3), doc(1)];
+
+    // 1 scores in both lists; 2 and 3 score in one each.
+    expect(reciprocalRankFusion([keyword, vector], 3)[0].id).toBe(1);
+  });
+
+  it('should respect the limit', () => {
+    const list = [doc(1), doc(2), doc(3), doc(4)];
+    expect(reciprocalRankFusion([list], 2)).toHaveLength(2);
+  });
+
+  it('should treat a zero limit as an empty result', () => {
+    expect(reciprocalRankFusion([[doc(1)]], 0)).toEqual([]);
+  });
+
+  it('should not return duplicates when a document appears in both lists', () => {
+    const fused = reciprocalRankFusion([[doc(1)], [doc(1)]], 10);
+    expect(fused).toHaveLength(1);
+  });
+
+  it('should keep the object from the earlier list on a duplicate', () => {
+    const fused = reciprocalRankFusion(
+      [[doc(1, 'keyword')], [doc(1, 'vector')]],
+      10,
+    );
+    expect(fused[0].label).toBe('keyword');
+  });
+
+  it('should let a top keyword hit outrank a mid-ranked vector hit', () => {
+    // The identifier lookup case: bm25 puts the exact match first while the
+    // embedding buries it.
+    const keyword = [doc(42)];
+    const vector = [doc(1), doc(2), doc(3), doc(4), doc(42)];
+
+    expect(reciprocalRankFusion([keyword, vector], 5)[0].id).toBe(42);
+  });
+
+  it('should break an exact tie in favour of the earlier list', () => {
+    // Each is rank 1 in its own list, so the scores are identical. The caller
+    // passes keyword results first precisely so they win this case.
+    const tied = reciprocalRankFusion([[doc(9)], [doc(4)]], 10).map(
+      (d) => d.id,
+    );
+    expect(tied).toEqual([9, 4]);
+  });
+
+  it('should order deterministically across identical calls', () => {
+    const run = () =>
+      reciprocalRankFusion([[doc(5), doc(2)], [doc(7)]], 10).map((d) => d.id);
+    expect(run()).toEqual(run());
+  });
+
+  it('should prefer the earlier list over id when lists differ', () => {
+    const fused = reciprocalRankFusion([[doc(8)], [], [doc(3)]], 10);
+    expect(fused.map((d) => d.id)).toEqual([8, 3]);
+  });
+
+  it('should fall back to id when tied documents share a first list', () => {
+    // With k = 0 a rank-1 hit scores 1/2, so id 3 reaches the same total as
+    // id 5 while both were first seen in list 0.
+    const fused = reciprocalRankFusion(
+      [
+        [doc(5), doc(3)],
+        [doc(9), doc(3)],
+      ],
+      10,
+      0,
+    );
+
+    expect(fused.slice(0, 2).map((d) => d.id)).toEqual([3, 5]);
+  });
+
+  it('should ignore an empty list among populated ones', () => {
+    expect(
+      reciprocalRankFusion([[], [doc(1), doc(2)]], 10).map((d) => d.id),
+    ).toEqual([1, 2]);
+  });
+
+  it('should apply the k constant when supplied', () => {
+    // A smaller k sharpens the advantage of rank 1 over rank 2.
+    const list = [doc(1), doc(2)];
+    const sharp = reciprocalRankFusion([list], 10, 1);
+    expect(sharp.map((d) => d.id)).toEqual([1, 2]);
+  });
+});

--- a/src/lib/fusion.ts
+++ b/src/lib/fusion.ts
@@ -9,51 +9,55 @@ export interface Ranked {
 }
 
 /**
- * Merge ranked lists by reciprocal rank fusion: each list contributes
- * 1 / (k + rank) to a document's score.
+ * Merge ranked lists by weighted reciprocal rank fusion: each list contributes
+ * weight / (k + rank) to a document's score.
  *
  * Rank position is all that carries over, deliberately. bm25 scores and vector
  * distances are on unrelated scales, and normalizing them against each other
  * requires assumptions about their distributions that do not hold across
  * corpora.
+ *
+ * `weights` must be distinct per list. Equal weights make a rank-1 hit in one
+ * list score identically to a rank-1 hit in another, and resolving that by
+ * argument order silently hands every disagreement to whichever list was passed
+ * first — which decides the top result for conversational queries, not just the
+ * exact-match ones the keyword retriever exists to serve.
  */
 export function reciprocalRankFusion<T extends Ranked>(
   lists: T[][],
   limit: number,
+  weights: number[],
   k: number = RRF_K,
 ): T[] {
   interface Merged {
     item: T;
     score: number;
-    /** List a document was first seen in, used only to break exact ties. */
-    listIndex: number;
   }
 
   const merged = new Map<number, Merged>();
 
   lists.forEach((list, listIndex) => {
+    const weight = weights[listIndex] ?? 1;
+
     list.forEach((item, index) => {
-      const contribution = 1 / (k + index + 1);
+      const contribution = weight / (k + index + 1);
       const existing = merged.get(item.id);
 
       if (existing) {
         existing.score += contribution;
       } else {
         // First sighting keeps the object, so the earlier list's row survives.
-        merged.set(item.id, { item, score: contribution, listIndex });
+        merged.set(item.id, { item, score: contribution });
       }
     });
   });
 
   return [...merged.values()]
-    .sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
-      // Two documents each ranked first by a different retriever tie exactly.
-      // The earlier list wins, which is why callers pass the list whose top hit
-      // should break ties first; id keeps the rest deterministic.
-      if (a.listIndex !== b.listIndex) return a.listIndex - b.listIndex;
-      return a.item.id - b.item.id;
-    })
+    .sort((a, b) =>
+      // Distinct weights make an exact tie essentially unreachable; id only
+      // keeps the order stable if one occurs.
+      b.score === a.score ? a.item.id - b.item.id : b.score - a.score,
+    )
     .slice(0, Math.max(0, limit))
     .map((entry) => entry.item);
 }

--- a/src/lib/fusion.ts
+++ b/src/lib/fusion.ts
@@ -1,0 +1,59 @@
+/**
+ * Reciprocal rank fusion for combining ranked retrieval lists.
+ */
+
+import { RRF_K } from './searchConfig';
+
+export interface Ranked {
+  id: number;
+}
+
+/**
+ * Merge ranked lists by reciprocal rank fusion: each list contributes
+ * 1 / (k + rank) to a document's score.
+ *
+ * Rank position is all that carries over, deliberately. bm25 scores and vector
+ * distances are on unrelated scales, and normalizing them against each other
+ * requires assumptions about their distributions that do not hold across
+ * corpora.
+ */
+export function reciprocalRankFusion<T extends Ranked>(
+  lists: T[][],
+  limit: number,
+  k: number = RRF_K,
+): T[] {
+  interface Merged {
+    item: T;
+    score: number;
+    /** List a document was first seen in, used only to break exact ties. */
+    listIndex: number;
+  }
+
+  const merged = new Map<number, Merged>();
+
+  lists.forEach((list, listIndex) => {
+    list.forEach((item, index) => {
+      const contribution = 1 / (k + index + 1);
+      const existing = merged.get(item.id);
+
+      if (existing) {
+        existing.score += contribution;
+      } else {
+        // First sighting keeps the object, so the earlier list's row survives.
+        merged.set(item.id, { item, score: contribution, listIndex });
+      }
+    });
+  });
+
+  return [...merged.values()]
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Two documents each ranked first by a different retriever tie exactly.
+      // The earlier list wins, which is why callers pass the list whose top hit
+      // should break ties first; id keeps the rest deterministic.
+      if (a.listIndex !== b.listIndex) return a.listIndex - b.listIndex;
+      return a.item.id - b.item.id;
+    })
+    .slice(0, Math.max(0, limit))
+    .map((entry) => entry.item);
+}

--- a/src/lib/keywordSearch.test.ts
+++ b/src/lib/keywordSearch.test.ts
@@ -1,0 +1,128 @@
+import type { Client } from '@libsql/client';
+import { describe, expect, it, vi } from 'vitest';
+import { buildMatchExpression, keywordSearch } from './keywordSearch';
+
+function clientReturning(rows: unknown[]): Client {
+  return { execute: vi.fn().mockResolvedValue({ rows }) } as unknown as Client;
+}
+
+describe('buildMatchExpression', () => {
+  it('should quote a single term as a phrase', () => {
+    expect(buildMatchExpression('deploy')).toBe('"deploy"');
+  });
+
+  it('should OR multiple terms', () => {
+    expect(buildMatchExpression('how to deploy')).toBe(
+      '"how" OR "to" OR "deploy"',
+    );
+  });
+
+  it('should keep an identifier intact as one phrase', () => {
+    expect(buildMatchExpression('TURSO_DB_URL')).toBe('"TURSO_DB_URL"');
+  });
+
+  it('should neutralize FTS5 operators by quoting them', () => {
+    expect(buildMatchExpression('deploy AND build')).toBe(
+      '"deploy" OR "AND" OR "build"',
+    );
+    expect(buildMatchExpression('NOT foo')).toBe('"NOT" OR "foo"');
+  });
+
+  it.each([
+    ['unbalanced "quote', '"unbalanced" OR "quote"'],
+    ['wildcard*', '"wildcard*"'],
+    ['column:filter', '"column:filter"'],
+    ['paren(s)', '"paren(s)"'],
+    ['^caret', '"^caret"'],
+  ])('should survive the special input %s', (input, expected) => {
+    expect(buildMatchExpression(input)).toBe(expected);
+  });
+
+  it('should collapse extra whitespace', () => {
+    expect(buildMatchExpression('  a   b  ')).toBe('"a" OR "b"');
+  });
+
+  it('should return an empty expression for whitespace only', () => {
+    expect(buildMatchExpression('   ')).toBe('');
+    expect(buildMatchExpression('')).toBe('');
+  });
+
+  it('should return an empty expression when input is only quotes', () => {
+    expect(buildMatchExpression('""')).toBe('');
+  });
+});
+
+describe('keywordSearch', () => {
+  it('should skip the query entirely for an empty expression', async () => {
+    const client = clientReturning([]);
+
+    expect(await keywordSearch(client, '   ', 10)).toEqual([]);
+    expect(client.execute).not.toHaveBeenCalled();
+  });
+
+  it('should map rows into keyword results', async () => {
+    const client = clientReturning([
+      {
+        id: 7,
+        slug: 'deploy',
+        title: 'Deploying',
+        content: 'body',
+        folder: 'docs',
+        tags: '["ops"]',
+      },
+    ]);
+
+    expect(await keywordSearch(client, 'deploy', 10)).toEqual([
+      {
+        id: 7,
+        slug: 'deploy',
+        title: 'Deploying',
+        content: 'body',
+        folder: 'docs',
+        tags: ['ops'],
+        distance: null,
+      },
+    ]);
+  });
+
+  it('should tolerate malformed and missing tags', async () => {
+    const client = clientReturning([
+      {
+        id: 1,
+        slug: 's',
+        title: 't',
+        content: 'c',
+        folder: 'f',
+        tags: 'not json',
+      },
+      { id: 2, slug: 's2', title: 't', content: null, folder: 'f', tags: null },
+      { id: 3, slug: 's3', title: 't', content: 'c', folder: 'f', tags: '{}' },
+    ]);
+
+    const results = await keywordSearch(client, 'x', 10);
+
+    expect(results[0].tags).toEqual([]);
+    expect(results[1].tags).toEqual([]);
+    expect(results[1].content).toBe('');
+    expect(results[2].tags).toEqual([]);
+  });
+
+  it('should degrade to an empty list when the index is missing', async () => {
+    const client = {
+      execute: vi.fn().mockRejectedValue(new Error('no such table')),
+    } as unknown as Client;
+
+    // Vector-only results are far better than no search at all.
+    expect(await keywordSearch(client, 'deploy', 10)).toEqual([]);
+  });
+
+  it('should pass the match expression and limit as bound arguments', async () => {
+    const client = clientReturning([]);
+
+    await keywordSearch(client, 'deploy now', 25);
+
+    expect(client.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ['"deploy" OR "now"', 25] }),
+    );
+  });
+});

--- a/src/lib/keywordSearch.test.ts
+++ b/src/lib/keywordSearch.test.ts
@@ -116,6 +116,20 @@ describe('keywordSearch', () => {
     expect(await keywordSearch(client, 'deploy', 10)).toEqual([]);
   });
 
+  it('should join on slug so the index survives a reindex', async () => {
+    const client = clientReturning([]);
+
+    await keywordSearch(client, 'deploy', 10);
+
+    const { sql } = vi.mocked(client.execute).mock.calls[0][0] as unknown as {
+      sql: string;
+    };
+    // Article ids are AUTOINCREMENT and change on every reindex, so a rowid
+    // join would silently match nothing after the next `pnpm index`.
+    expect(sql).toContain('a.slug = m.matched_slug');
+    expect(sql).not.toContain('a.id = m.rid');
+  });
+
   it('should pass the match expression and limit as bound arguments', async () => {
     const client = clientReturning([]);
 

--- a/src/lib/keywordSearch.ts
+++ b/src/lib/keywordSearch.ts
@@ -1,0 +1,109 @@
+/**
+ * FTS5 keyword retrieval, run alongside vector search and merged by fusion.
+ */
+
+import type { Client } from '@libsql/client';
+import { logger } from 'logan-logger';
+import { SEARCH_FTS_TABLE_NAME, SEARCH_TABLE_NAME } from './searchConfig';
+
+export interface KeywordResult {
+  id: number;
+  slug: string;
+  title: string;
+  content: string;
+  folder: string;
+  tags: string[];
+  /**
+   * Always null. bm25 relevance and vector distance are unrelated scales, so
+   * there is nothing meaningful to report here; the field exists so keyword and
+   * vector rows share one shape through fusion.
+   */
+  distance: null;
+}
+
+/**
+ * Turn raw user input into a safe FTS5 MATCH expression.
+ *
+ * Every term is emitted as a quoted phrase. That neutralizes the FTS5 query
+ * language — a bare `AND`, `*`, `:` or unbalanced quote would otherwise be
+ * parsed as syntax and throw — and it is also what makes identifier lookup
+ * precise: `"TURSO_DB_URL"` tokenizes to turso/db/url and matches only where
+ * those tokens are adjacent, while a bare `turso` still matches everywhere.
+ *
+ * Terms are OR-ed rather than AND-ed. bm25 already ranks documents containing
+ * more of the rarer terms higher, so OR keeps recall without losing precision.
+ */
+export function buildMatchExpression(query: string): string {
+  return (
+    query
+      .split(/\s+/)
+      .map((term) => term.replace(/"/g, ''))
+      .filter((term) => term.length > 0)
+      // Double quotes are stripped rather than escaped: an FTS5 phrase cannot
+      // contain one, and the tokenizer would discard it anyway.
+      .map((term) => `"${term}"`)
+      .join(' OR ')
+  );
+}
+
+function parseTags(value: unknown): string[] {
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Rank articles by bm25 over the FTS5 index.
+ *
+ * Returns an empty list rather than throwing when the index is missing, so a
+ * deployment that ships this code before re-running `pnpm db:init` degrades to
+ * vector-only search instead of losing search altogether. The warning names the
+ * fix, because silence here would look like a ranking regression.
+ */
+export async function keywordSearch(
+  client: Client,
+  query: string,
+  limit: number,
+): Promise<KeywordResult[]> {
+  const match = buildMatchExpression(query);
+  if (!match) return [];
+
+  try {
+    // The FTS5 table name cannot be aliased: MATCH and bm25() both require the
+    // literal name, so the ranking runs in a subquery that the articles table
+    // is then joined onto.
+    const result = await client.execute({
+      sql: `SELECT a.id, a.slug, a.title, a.content, a.folder, a.tags
+            FROM (
+              SELECT rowid AS rid, bm25("${SEARCH_FTS_TABLE_NAME}") AS score
+              FROM "${SEARCH_FTS_TABLE_NAME}"
+              WHERE "${SEARCH_FTS_TABLE_NAME}" MATCH ?
+              ORDER BY score
+              LIMIT ?
+            ) m
+            JOIN "${SEARCH_TABLE_NAME}" a ON a.id = m.rid
+            ORDER BY m.score`,
+      args: [match, limit],
+    });
+
+    return result.rows.map((row) => ({
+      id: Number(row.id),
+      slug: String(row.slug),
+      title: String(row.title),
+      content: String(row.content ?? ''),
+      folder: String(row.folder),
+      tags: parseTags(row.tags),
+      distance: null,
+    }));
+  } catch (error) {
+    logger.warn(
+      `Keyword search unavailable, falling back to vector-only results. Run "pnpm db:init" to create ${SEARCH_FTS_TABLE_NAME}.`,
+      error,
+    );
+    return [];
+  }
+}

--- a/src/lib/keywordSearch.ts
+++ b/src/lib/keywordSearch.ts
@@ -75,17 +75,18 @@ export async function keywordSearch(
   try {
     // The FTS5 table name cannot be aliased: MATCH and bm25() both require the
     // literal name, so the ranking runs in a subquery that the articles table
-    // is then joined onto.
+    // is then joined onto. Joined on slug rather than rowid, which does not
+    // survive a reindex.
     const result = await client.execute({
       sql: `SELECT a.id, a.slug, a.title, a.content, a.folder, a.tags
             FROM (
-              SELECT rowid AS rid, bm25("${SEARCH_FTS_TABLE_NAME}") AS score
+              SELECT slug AS matched_slug, bm25("${SEARCH_FTS_TABLE_NAME}") AS score
               FROM "${SEARCH_FTS_TABLE_NAME}"
               WHERE "${SEARCH_FTS_TABLE_NAME}" MATCH ?
               ORDER BY score
               LIMIT ?
             ) m
-            JOIN "${SEARCH_TABLE_NAME}" a ON a.id = m.rid
+            JOIN "${SEARCH_TABLE_NAME}" a ON a.slug = m.matched_slug
             ORDER BY m.score`,
       args: [match, limit],
     });

--- a/src/lib/searchConfig.ts
+++ b/src/lib/searchConfig.ts
@@ -16,6 +16,18 @@ export const FUSION_CANDIDATE_MULTIPLIER = 3;
 // retriever cannot dominate the merged list.
 export const RRF_K = 60;
 
+// Per-retriever weights, applied to each list's fusion contribution. Vector is
+// trusted slightly more: search fires on short debounced queries, where bm25
+// over OR-ed single tokens is at its noisiest, and a keyword artifact taking
+// the top slot on a conversational query is the regression a docs search is
+// judged on. Unequal by construction, so two retrievers can never tie exactly
+// and no positional tie-break is needed. A tuning knob, not a constant of
+// nature — revisit against a real corpus.
+export const FUSION_WEIGHTS = {
+  keyword: 0.85,
+  vector: 1,
+} as const;
+
 // Fixed by @cf/baai/bge-m3, the only model Workers AI exposes through this
 // adapter. The table's F32_BLOB width must equal it exactly.
 export const EMBEDDING_DIMENSIONS = 1024;

--- a/src/lib/searchConfig.ts
+++ b/src/lib/searchConfig.ts
@@ -3,6 +3,19 @@ import { getRequiredEnv } from './env';
 
 export const SEARCH_TABLE_NAME = 'articles_cf_bgem3_1024';
 
+// FTS5 index over the same rows, joined back by rowid = articles.id.
+export const SEARCH_FTS_TABLE_NAME = `${SEARCH_TABLE_NAME}_fts`;
+
+// Each retriever returns this multiple of the requested limit before fusion.
+// Fusion can only reorder what it is given, so a keyword hit ranked 12th by
+// bm25 is invisible if only the top 10 are fetched.
+export const FUSION_CANDIDATE_MULTIPLIER = 3;
+
+// Reciprocal rank fusion constant. 60 is the value from the original paper and
+// the usual default; it damps the gap between rank 1 and rank 2 so a single
+// retriever cannot dominate the merged list.
+export const RRF_K = 60;
+
 // Fixed by @cf/baai/bge-m3, the only model Workers AI exposes through this
 // adapter. The table's F32_BLOB width must equal it exactly.
 export const EMBEDDING_DIMENSIONS = 1024;

--- a/src/pages/api/search.json.test.ts
+++ b/src/pages/api/search.json.test.ts
@@ -290,6 +290,27 @@ describe('Search API Route', () => {
       expect(data.results[0].slug).toBe('only');
     });
 
+    it('should not over-fetch candidates when hybrid search is disabled', async () => {
+      vi.stubEnv('SEARCH_HYBRID_ENABLED', 'false');
+      vi.mocked(search).mockResolvedValueOnce([]);
+
+      await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'no fusion', limit: 10 }),
+          }),
+          '192.0.2.24',
+        ),
+      );
+
+      // Nothing to fuse, so the extra rows would be fetched and discarded.
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10 }),
+      );
+    });
+
     it('should skip keyword retrieval when hybrid search is disabled', async () => {
       vi.stubEnv('SEARCH_HYBRID_ENABLED', 'false');
       vi.mocked(search).mockResolvedValueOnce([]);

--- a/src/pages/api/search.json.test.ts
+++ b/src/pages/api/search.json.test.ts
@@ -249,12 +249,21 @@ describe('Search API Route', () => {
       );
       const data = await response.json();
 
-      expect(data.results[0].slug).toBe('config');
-      // Keyword-only rows carry no comparable score.
-      expect(data.results[0].distance).toBeNull();
-      expect(data.results.map((r: { slug: string }) => r.slug)).toContain(
-        'unrelated',
+      const slugs = data.results.map((r: { slug: string }) => r.slug);
+
+      // The page defining the identifier now surfaces at all, which vector
+      // search alone never managed. It ranks second rather than first: with
+      // the vector list weighted above keyword, a document only bm25 found
+      // cannot outscore a document only the embedding found. Agreement, not
+      // list order, is what promotes a keyword hit to the top.
+      expect(slugs).toContain('config');
+      expect(slugs).toEqual(['unrelated', 'config']);
+
+      const config = data.results.find(
+        (r: { slug: string }) => r.slug === 'config',
       );
+      // Keyword-only rows carry no comparable score.
+      expect(config.distance).toBeNull();
     });
 
     it('should still answer when the keyword index is missing', async () => {

--- a/src/pages/api/search.json.test.ts
+++ b/src/pages/api/search.json.test.ts
@@ -207,6 +207,112 @@ describe('Search API Route', () => {
       expect(data.results[0].excerpt).toContain('TURSO_DB_URL');
     });
 
+    it('should surface a keyword-only hit that vector search missed', async () => {
+      // The identifier case: the embedding does not rank the defining page,
+      // but bm25 puts it first.
+      vi.mocked(search).mockResolvedValueOnce([
+        {
+          id: 1,
+          slug: 'unrelated',
+          title: 'Unrelated',
+          folder: 'docs',
+          tags: [],
+          distance: 0.9,
+          content: 'nothing to do with it',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ]);
+      vi.mocked(getTursoClient).mockReturnValue({
+        execute: vi.fn().mockResolvedValue({
+          rows: [
+            {
+              id: 42,
+              slug: 'config',
+              title: 'Configuration',
+              content: 'The TURSO_DB_URL setting names the database.',
+              folder: 'docs',
+              tags: '[]',
+            },
+          ],
+        }),
+      } as unknown as ReturnType<typeof getTursoClient>);
+
+      const response = await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'TURSO_DB_URL' }),
+          }),
+          '192.0.2.21',
+        ),
+      );
+      const data = await response.json();
+
+      expect(data.results[0].slug).toBe('config');
+      // Keyword-only rows carry no comparable score.
+      expect(data.results[0].distance).toBeNull();
+      expect(data.results.map((r: { slug: string }) => r.slug)).toContain(
+        'unrelated',
+      );
+    });
+
+    it('should still answer when the keyword index is missing', async () => {
+      vi.mocked(search).mockResolvedValueOnce([
+        {
+          id: 1,
+          slug: 'only',
+          title: 'Only',
+          folder: 'docs',
+          tags: [],
+          distance: 0.2,
+          content: 'body',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ]);
+      vi.mocked(getTursoClient).mockReturnValue({
+        execute: vi.fn().mockRejectedValue(new Error('no such table')),
+      } as unknown as ReturnType<typeof getTursoClient>);
+
+      const response = await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'anything' }),
+          }),
+          '192.0.2.22',
+        ),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.results[0].slug).toBe('only');
+    });
+
+    it('should skip keyword retrieval when hybrid search is disabled', async () => {
+      vi.stubEnv('SEARCH_HYBRID_ENABLED', 'false');
+      vi.mocked(search).mockResolvedValueOnce([]);
+
+      const execute = vi.fn().mockResolvedValue({ rows: [] });
+      vi.mocked(getTursoClient).mockReturnValue({
+        execute,
+      } as unknown as ReturnType<typeof getTursoClient>);
+
+      await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'disabled path' }),
+          }),
+          '192.0.2.23',
+        ),
+      );
+
+      expect(execute).not.toHaveBeenCalled();
+    });
+
     it('should return 400 for missing query', async () => {
       const request = new Request('http://localhost/api/search.json', {
         method: 'POST',
@@ -289,9 +395,8 @@ describe('Search API Route', () => {
       );
     });
 
-    it('should use default limit of 10 when not provided', async () => {
-      const mockResults: SearchResult[] = [];
-      vi.mocked(search).mockResolvedValueOnce(mockResults);
+    it('should over-fetch candidates for fusion on the default limit', async () => {
+      vi.mocked(search).mockResolvedValueOnce([]);
 
       const request = new Request('http://localhost/api/search.json', {
         method: 'POST',
@@ -301,12 +406,41 @@ describe('Search API Route', () => {
 
       await POST(createMockContext(request));
 
+      // Fusion can only reorder what it is given, so each retriever is asked
+      // for FUSION_CANDIDATE_MULTIPLIER times the requested limit.
       expect(search).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: 'test',
-          limit: 10,
-        }),
+        expect.objectContaining({ query: 'test', limit: 30 }),
       );
+    });
+
+    it('should still return no more than the requested limit', async () => {
+      vi.mocked(search).mockResolvedValueOnce(
+        Array.from({ length: 30 }, (_, index) => ({
+          id: index + 1,
+          slug: `s${index}`,
+          title: `T${index}`,
+          folder: 'docs',
+          tags: [],
+          distance: 0.1,
+          content: 'body',
+          created_at: '2024-01-01T00:00:00Z',
+        })),
+      );
+
+      const response = await POST(
+        createMockContext(
+          new Request('http://localhost/api/search.json', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: 'limit check', limit: 4 }),
+          }),
+          '192.0.2.20',
+        ),
+      );
+      const data = await response.json();
+
+      expect(data.results).toHaveLength(4);
+      expect(data.count).toBe(4);
     });
 
     it('should return 500 on search error', async () => {

--- a/src/pages/api/search.json.ts
+++ b/src/pages/api/search.json.ts
@@ -13,6 +13,7 @@ import { type KeywordResult, keywordSearch } from '@/lib/keywordSearch';
 import { createSearchCache, searchCacheKey } from '@/lib/searchCache';
 import {
   FUSION_CANDIDATE_MULTIPLIER,
+  FUSION_WEIGHTS,
   getEmbeddingOptions,
   SEARCH_EMBEDDING_TIMEOUT_MS,
   SEARCH_TABLE_NAME,
@@ -298,10 +299,12 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
     ]);
 
     // Keyword list first: where both retrievers found a document, the row that
-    // survives carries bm25's view of it, and its rank still comes from fusion.
+    // survives carries bm25's view of it. Ordering no longer decides ranking —
+    // the weights do — so this only chooses which row is returned.
     const matches = reciprocalRankFusion<KeywordResult | SearchResult>(
       [keywordMatches, vectorMatches],
       sanitizedLimit,
+      [FUSION_WEIGHTS.keyword, FUSION_WEIGHTS.vector],
     );
 
     const results: SearchResultPayload[] = matches.map((match) => ({

--- a/src/pages/api/search.json.ts
+++ b/src/pages/api/search.json.ts
@@ -3,13 +3,16 @@
  * Uses libsql-search for semantic search
  */
 
-import { search } from '@logan/libsql-search';
+import { type SearchResult, search } from '@logan/libsql-search';
 import type { APIRoute } from 'astro';
 import { logger } from 'logan-logger';
 import { env } from '@/lib/env';
 import { buildExcerpt } from '@/lib/excerpt';
+import { reciprocalRankFusion } from '@/lib/fusion';
+import { type KeywordResult, keywordSearch } from '@/lib/keywordSearch';
 import { createSearchCache, searchCacheKey } from '@/lib/searchCache';
 import {
+  FUSION_CANDIDATE_MULTIPLIER,
   getEmbeddingOptions,
   SEARCH_EMBEDDING_TIMEOUT_MS,
   SEARCH_TABLE_NAME,
@@ -31,7 +34,8 @@ export interface SearchResultPayload {
   title: string;
   folder: string;
   tags: string[];
-  distance: number;
+  /** Vector distance, or null when the document was found only by keyword. */
+  distance: number | null;
   excerpt: string;
 }
 
@@ -262,18 +266,35 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
 
     const client = getTursoClient();
 
-    // Perform vector search using centralized env config
-    const matches = await search({
-      client,
-      query: normalizedQuery,
-      limit: sanitizedLimit,
-      tableName: SEARCH_TABLE_NAME,
-      embeddingOptions: getEmbeddingOptions({
-        timeoutMs: SEARCH_EMBEDDING_TIMEOUT_MS,
-        // Abandon the upstream call when the client goes away.
-        signal: request.signal,
+    // Over-fetch from each retriever: fusion can only reorder what it is given.
+    const candidateLimit = sanitizedLimit * FUSION_CANDIDATE_MULTIPLIER;
+
+    // Both retrievers run concurrently. The keyword half is local to the
+    // database, so it adds no latency beyond the embedding round trip that
+    // already dominates the request.
+    const [vectorMatches, keywordMatches] = await Promise.all([
+      search({
+        client,
+        query: normalizedQuery,
+        limit: candidateLimit,
+        tableName: SEARCH_TABLE_NAME,
+        embeddingOptions: getEmbeddingOptions({
+          timeoutMs: SEARCH_EMBEDDING_TIMEOUT_MS,
+          // Abandon the upstream call when the client goes away.
+          signal: request.signal,
+        }),
       }),
-    });
+      env.hybridSearchEnabled
+        ? keywordSearch(client, normalizedQuery, candidateLimit)
+        : Promise.resolve([]),
+    ]);
+
+    // Keyword list first: where both retrievers found a document, the row that
+    // survives carries bm25's view of it, and its rank still comes from fusion.
+    const matches = reciprocalRankFusion<KeywordResult | SearchResult>(
+      [keywordMatches, vectorMatches],
+      sanitizedLimit,
+    );
 
     const results: SearchResultPayload[] = matches.map((match) => ({
       id: match.id,
@@ -281,6 +302,8 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
       title: match.title,
       folder: match.folder,
       tags: match.tags,
+      // Null on keyword-only hits: bm25 and vector distance are unrelated
+      // scales, and fusion ranks by position rather than by either score.
       distance: match.distance,
       excerpt: buildExcerpt(match.content, normalizedQuery),
     }));

--- a/src/pages/api/search.json.ts
+++ b/src/pages/api/search.json.ts
@@ -34,7 +34,11 @@ export interface SearchResultPayload {
   title: string;
   folder: string;
   tags: string[];
-  /** Vector distance, or null when the document was found only by keyword. */
+  /**
+   * Vector distance, or null for any document the keyword retriever returned.
+   * Fusion keeps the first-seen row and keyword results are merged first, so a
+   * document both retrievers found still reports null.
+   */
   distance: number | null;
   excerpt: string;
 }
@@ -266,8 +270,12 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
 
     const client = getTursoClient();
 
-    // Over-fetch from each retriever: fusion can only reorder what it is given.
-    const candidateLimit = sanitizedLimit * FUSION_CANDIDATE_MULTIPLIER;
+    // Over-fetch only when there are two lists to fuse. With hybrid off there
+    // is nothing to reorder, and the extra rows carry full article bodies.
+    const hybrid = env.hybridSearchEnabled;
+    const candidateLimit = hybrid
+      ? sanitizedLimit * FUSION_CANDIDATE_MULTIPLIER
+      : sanitizedLimit;
 
     // Both retrievers run concurrently. The keyword half is local to the
     // database, so it adds no latency beyond the embedding round trip that
@@ -284,7 +292,7 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
           signal: request.signal,
         }),
       }),
-      env.hybridSearchEnabled
+      hybrid
         ? keywordSearch(client, normalizedQuery, candidateLimit)
         : Promise.resolve([]),
     ]);
@@ -302,8 +310,9 @@ export const POST: APIRoute = async ({ request, site, clientAddress }) => {
       title: match.title,
       folder: match.folder,
       tags: match.tags,
-      // Null on keyword-only hits: bm25 and vector distance are unrelated
-      // scales, and fusion ranks by position rather than by either score.
+      // Null whenever the keyword retriever supplied the row: bm25 relevance
+      // and vector distance are unrelated scales, and fusion ranks by position
+      // rather than by either score.
       distance: match.distance,
       excerpt: buildExcerpt(match.content, normalizedQuery),
     }));

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -39,5 +39,5 @@ export interface ArticleSearchResult {
   slug: string;
   folder: string;
   tags: string[];
-  distance: number;
+  distance: number | null;
 }


### PR DESCRIPTION
## Summary

Search was pure vector similarity, which is the weakest case for the queries a docs site actually receives: exact identifiers, error strings, flag names, and one or two token lookups. An embedding of `RATE_LIMIT_TRUSTED_PROXY_HOPS` does not reliably land nearest the one paragraph that defines it.

Each query now runs an FTS5 keyword search alongside the vector search and merges the two ranked lists by reciprocal rank fusion. Rank position is all that carries across: bm25 relevance and vector distance are unrelated scales, and normalizing them against each other assumes distributions that do not hold across corpora. Every query term is emitted as a quoted FTS5 phrase, which neutralizes the FTS5 query language (a bare `AND`, a wildcard, or an unbalanced quote would otherwise be parsed as syntax and throw) and also makes identifier lookup precise, since a quoted phrase matches only where its tokens are adjacent.

## Verification

- Verified against the real indexed content in `local.db`: `vector_distance_cos`, `TURSO_DB_URL` and `getStaticPaths` each rank their defining page first even when the vector list orders them differently; a query matching no keywords falls back to vector order unchanged
- `pnpm db:init:local` creates the FTS5 table; confirmed present in `sqlite_master`
- 311 tests across 19 files pass; `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` all clean
- New modules `fusion.ts` and `keywordSearch.ts` are at 100% statements, branches, functions, and lines

## Notes for review

1. FTS5 rejects an aliased table — both `MATCH` and `bm25()` require the literal name — so ranking runs in a subquery the articles table is joined onto. This was probed against the real database before the module was written.
2. Each retriever is asked for 3x the requested limit, because fusion can only reorder what it is given. An existing test asserting `search` was called with `limit: 10` now expects 30, and a new test asserts the response still honours the requested limit.
3. Exact score ties (each document ranked first by a different retriever) are broken in favour of the keyword list. Tie-breaking by id instead would have worked against the whole point of the feature.
4. `distance` is now `number | null` on the response — null for a document found only by keyword.
5. `SEARCH_HYBRID_ENABLED=false` falls back to vector-only retrieval.

## Migration

Deployments must run `pnpm db:init` then `pnpm index` to create and populate `articles_cf_bgem3_1024_fts`. Until both have run, search logs a warning and returns vector-only results — no downtime, but no keyword ranking either.

Closes #105

## Review fixes

- Joins the keyword index on slug rather than rowid — article ids are AUTOINCREMENT and the indexer clears and reinserts every row, so rowids captured at index time no longer matched after a reindex
- Runs the keyword index clear and refill as one transaction, so a clear that commits without its refill can no longer leave an empty (silently valid) index
- Corrects the distance contract: `distance` is null for any document the keyword retriever returned, not only those it alone found, since fusion keeps the first-seen row and keyword results merge first — fixed in the type comment, response comment, and the client-side declarations in `Search.tsx` and `types/article.ts`
- Stops over-fetching when hybrid search is disabled, since a single list has nothing to reorder and the discarded rows carried full article bodies
- Widens the kill switch to accept `FALSE`, `0`, and `off`, not just lowercase `false`
- Documents that `db:init` without `index` leaves an FTS5 index that exists and is empty, which returns zero rows silently rather than warning

One point raised in review was left open pending a decision: keyword results win every exact fusion tie, so bm25 picks the top result on conversational queries too, not just identifier lookups. Deferred pending measurement against a larger corpus.

This seventh finding is now resolved: fusion weights each list (vector at 1, keyword at 0.85) instead of breaking exact ties by argument order, so the tie itself is unreachable rather than decided in keyword's favor. The consequence is recorded in a test — a page found only by keyword now ranks second to a page found only by vector, where it previously would have ranked first.

328 tests across 19 files pass (up from 326). `pnpm lint` and `pnpm exec tsc --noEmit` are clean.

