### PR TITLE
ci: index, build and smoke-test without credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,12 @@ CLOUDFLARE_API_TOKEN=your-api-token
 # Hybrid retrieval: FTS5 keyword results fused with vector results.
 # Set to false to fall back to vector-only search.
 # SEARCH_HYBRID_ENABLED=true
+
+# Offline embeddings for CI, forks, and local work without credentials.
+# When set, an OpenAI-compatible service at this URL replaces Workers AI for
+# both indexing and search. Start one with `pnpm embeddings:offline`.
+# Its vectors are a different embedding space, so they get their own table
+# (articles_offline_hash_1024) and can never mix with the Workers AI vectors.
+# Leave unset in production.
+# OFFLINE_EMBEDDINGS_BASE_URL=http://127.0.0.1:8788/v1
+# OFFLINE_EMBEDDINGS_PORT=8788

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,13 @@ on:
   pull_request:
     branches: [ main, dev ]
 
+env:
+  OFFLINE_EMBEDDINGS_PORT: '8788'
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    env:
-      # Deterministic local embeddings, so indexing, prerendering and search run
-      # identically for fork and Dependabot PRs, which never receive secrets.
-      OFFLINE_EMBEDDINGS_BASE_URL: http://127.0.0.1:8788/v1
-      OFFLINE_EMBEDDINGS_PORT: '8788'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +29,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Deliberately without OFFLINE_EMBEDDINGS_BASE_URL: the unit suite asserts
+      # the Workers AI branch, and that variable switches provider and table.
       - name: Run tests with coverage
         run: pnpm test:coverage --run
 
@@ -39,23 +39,33 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      # Deterministic local embeddings from here down, so indexing, prerendering
+      # and search run identically for fork and Dependabot PRs, which never
+      # receive secrets.
       - name: Start offline embedding service
         run: |
-          pnpm embeddings:offline &
+          pnpm embeddings:offline > /tmp/offline-embeddings.log 2>&1 &
           for _ in $(seq 1 40); do
             curl -sf "http://127.0.0.1:${OFFLINE_EMBEDDINGS_PORT}/health" >/dev/null && exit 0
             sleep 0.25
           done
           echo "offline embedding service did not start" >&2
+          cat /tmp/offline-embeddings.log >&2
           exit 1
 
       - name: Initialize local database
+        env:
+          OFFLINE_EMBEDDINGS_BASE_URL: http://127.0.0.1:8788/v1
         run: pnpm db:init:local
 
       - name: Index content to local database
+        env:
+          OFFLINE_EMBEDDINGS_BASE_URL: http://127.0.0.1:8788/v1
         run: pnpm index:local
 
       - name: Build
+        env:
+          OFFLINE_EMBEDDINGS_BASE_URL: http://127.0.0.1:8788/v1
         run: pnpm build
 
       # Exercises the built output: prerendered article pages, the health check,
@@ -63,4 +73,10 @@ jobs:
       # suite mocks all of this, so a dependency bump that breaks rendering or
       # search is invisible without it.
       - name: Smoke test the built server
+        env:
+          OFFLINE_EMBEDDINGS_BASE_URL: http://127.0.0.1:8788/v1
         run: pnpm smoke
+
+      - name: Offline embedding service log
+        if: failure()
+        run: cat /tmp/offline-embeddings.log || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    # Only a boolean lives at job level; a step cannot see its own `env` block
-    # from its condition, but the secrets themselves stay scoped to the one step
-    # that needs them rather than reaching every step in the job.
     env:
-      HAS_WORKERS_AI: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' && secrets.CLOUDFLARE_API_TOKEN != '' }}
+      # Deterministic local embeddings, so indexing, prerendering and search run
+      # identically for fork and Dependabot PRs, which never receive secrets.
+      OFFLINE_EMBEDDINGS_BASE_URL: http://127.0.0.1:8788/v1
+      OFFLINE_EMBEDDINGS_PORT: '8788'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,18 +39,28 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Start offline embedding service
+        run: |
+          pnpm embeddings:offline &
+          for _ in $(seq 1 40); do
+            curl -sf "http://127.0.0.1:${OFFLINE_EMBEDDINGS_PORT}/health" >/dev/null && exit 0
+            sleep 0.25
+          done
+          echo "offline embedding service did not start" >&2
+          exit 1
+
       - name: Initialize local database
         run: pnpm db:init:local
 
-      # Embeddings now come from Workers AI, so indexing needs credentials that
-      # fork PRs never receive. Without them the build still runs against the
-      # empty table created above and prerenders no article pages.
       - name: Index content to local database
-        if: env.HAS_WORKERS_AI == 'true'
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: pnpm index:local
 
       - name: Build
         run: pnpm build
+
+      # Exercises the built output: prerendered article pages, the health check,
+      # and a search request that embeds a query and reads vectors back. The unit
+      # suite mocks all of this, so a dependency bump that breaks rendering or
+      # search is invisible without it.
+      - name: Smoke test the built server
+        run: pnpm smoke

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ libSQL/Turso database, switch to the `.env`-driven commands in the docs.
 
 Text you index and every search query are sent to Cloudflare.
 
+### Without credentials
+
+To run the whole pipeline with no accounts at all, start the bundled offline
+embedding service in a second terminal and point the app at it:
+
+```bash
+pnpm embeddings:offline
+OFFLINE_EMBEDDINGS_BASE_URL=http://127.0.0.1:8788/v1 pnpm db:init:local
+OFFLINE_EMBEDDINGS_BASE_URL=http://127.0.0.1:8788/v1 pnpm index:local
+OFFLINE_EMBEDDINGS_BASE_URL=http://127.0.0.1:8788/v1 pnpm dev
+```
+
+This is what CI uses, so fork and Dependabot pull requests exercise indexing,
+prerendering, and search. Its vectors are a hashed bag of words rather than a
+model, and live in their own table — good enough to prove the pipeline runs, and
+not a basis for judging search quality.
+
 ## Documentation
 
 - [Docs index](./docs/README.md)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -64,6 +64,11 @@ CLOUDFLARE_ACCOUNT_ID=your-account-id
 CLOUDFLARE_API_TOKEN=your-api-token
 ```
 
+Leave `OFFLINE_EMBEDDINGS_BASE_URL` unset in production. It swaps in a
+deterministic local embedding service for CI and credential-free development,
+and points indexing and search at `articles_offline_hash_1024` instead — a
+different embedding space, and not a real model.
+
 ## Upgrade Note
 
 The current default index is `articles_cf_bgem3_1024`. Earlier releases embedded

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "uncov:check": "uncov check",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "format": "biome format --write ."
+    "format": "biome format --write .",
+    "embeddings:offline": "tsx scripts/offline-embedding-server.ts",
+    "smoke": "tsx scripts/smoke-test.ts"
   },
   "dependencies": {
     "@astrojs/node": "^11.1.5",

--- a/scripts/index-content.ts
+++ b/scripts/index-content.ts
@@ -31,9 +31,9 @@ if (!url || !authToken) {
 
 // Checked before any database work so missing credentials fail immediately
 // rather than after the table has been created.
-if (!env.hasCloudflareCredentials) {
+if (!env.hasEmbeddingProvider) {
   logger.error(
-    'Workers AI credentials are required to index content. Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN (see .env.example).',
+    'No embedding provider configured. Set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN, or OFFLINE_EMBEDDINGS_BASE_URL for a credential-free local service (see .env.example).',
   );
   process.exit(1);
 }

--- a/scripts/offline-embedding-server.test.ts
+++ b/scripts/offline-embedding-server.test.ts
@@ -1,5 +1,20 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createEmbeddingHandler, embedText } from './offline-embedding-server';
+/**
+ * @vitest-environment node
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  createEmbeddingHandler,
+  embedText,
+  startOfflineEmbeddingServer,
+} from './offline-embedding-server';
 
 const DIMENSIONS = 1024;
 
@@ -98,5 +113,87 @@ describe('createEmbeddingHandler', () => {
     ['zero dimensions', JSON.stringify({ input: ['a'], dimensions: 0 })],
   ])('rejects %s', (_label, body) => {
     expect(handle(body).status).toBe(400);
+  });
+});
+
+describe('startOfflineEmbeddingServer', () => {
+  let server: ReturnType<typeof startOfflineEmbeddingServer>;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    // Port 0 so parallel runs cannot collide on a fixed port.
+    server = startOfflineEmbeddingServer(0);
+    await new Promise<void>((resolve) => server.on('listening', resolve));
+    const address = server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('server did not bind a TCP port');
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('binds loopback only', () => {
+    const address = server.address();
+    expect(address).toMatchObject({ address: '127.0.0.1' });
+  });
+
+  it('answers the health probe', async () => {
+    const response = await fetch(`${baseUrl}/health`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: 'ok' });
+  });
+
+  it('serves the embeddings path under any base prefix', async () => {
+    const response = await fetch(`${baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: ['a', 'b'], dimensions: DIMENSIONS }),
+    });
+    const body = (await response.json()) as {
+      data: Array<{ index: number; embedding: number[] }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.data.map((item) => item.index)).toEqual([0, 1]);
+    expect(body.data[0].embedding).toHaveLength(DIMENSIONS);
+  });
+
+  it.each([
+    ['GET', '/v1/embeddings'],
+    ['POST', '/v1/nope'],
+  ])('404s %s %s', async (method, path) => {
+    const response = await fetch(`${baseUrl}${path}`, { method });
+
+    expect(response.status).toBe(404);
+  });
+
+  // An unbounded width reached new Array() and killed the process, which
+  // surfaced only as a connection error partway through indexing.
+  it('rejects an absurd width instead of dying', async () => {
+    const response = await fetch(`${baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: ['a'], dimensions: 2 ** 32 }),
+    });
+
+    expect(response.status).toBe(400);
+
+    const stillAlive = await fetch(`${baseUrl}/health`);
+    expect(stillAlive.status).toBe(200);
+  });
+
+  it('survives a malformed body', async () => {
+    const response = await fetch(`${baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    });
+
+    expect(response.status).toBe(400);
+    expect((await fetch(`${baseUrl}/health`)).status).toBe(200);
   });
 });

--- a/scripts/offline-embedding-server.test.ts
+++ b/scripts/offline-embedding-server.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createEmbeddingHandler, embedText } from './offline-embedding-server';
+
+const DIMENSIONS = 1024;
+
+function cosine(a: number[], b: number[]): number {
+  return a.reduce((sum, value, index) => sum + value * (b[index] ?? 0), 0);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('embedText', () => {
+  it('returns a unit vector of the requested width', () => {
+    const vector = embedText('semantic search', DIMENSIONS);
+
+    expect(vector).toHaveLength(DIMENSIONS);
+    expect(cosine(vector, vector)).toBeCloseTo(1, 10);
+  });
+
+  it('is deterministic across calls', () => {
+    expect(embedText('hybrid search', DIMENSIONS)).toEqual(
+      embedText('hybrid search', DIMENSIONS),
+    );
+  });
+
+  it('ignores case and punctuation, so the same words embed alike', () => {
+    expect(embedText('Vector Search!', DIMENSIONS)).toEqual(
+      embedText('vector search', DIMENSIONS),
+    );
+  });
+
+  it('scores shared tokens above disjoint ones', () => {
+    const document = embedText(
+      'semantic search over markdown documents',
+      DIMENSIONS,
+    );
+    const related = embedText('semantic search', DIMENSIONS);
+    const unrelated = embedText('quarterly financial projections', DIMENSIONS);
+
+    expect(cosine(document, related)).toBeGreaterThan(
+      cosine(document, unrelated),
+    );
+  });
+
+  it.each(['', '   ', '!!!'])('still returns a unit vector for %o', (text) => {
+    const vector = embedText(text, DIMENSIONS);
+
+    expect(vector).toHaveLength(DIMENSIONS);
+    expect(cosine(vector, vector)).toBeCloseTo(1, 10);
+  });
+});
+
+describe('createEmbeddingHandler', () => {
+  const handle = createEmbeddingHandler(DIMENSIONS);
+
+  it('returns one indexed embedding per input, in order', () => {
+    const { status, payload } = handle(
+      JSON.stringify({
+        input: ['one', 'two', 'three'],
+        dimensions: DIMENSIONS,
+      }),
+    );
+    const data = (payload as { data: Array<{ index: number }> }).data;
+
+    expect(status).toBe(200);
+    expect(data.map((item) => item.index)).toEqual([0, 1, 2]);
+  });
+
+  it('honours the requested dimensions', () => {
+    const { payload } = handle(
+      JSON.stringify({ input: ['one'], dimensions: 8 }),
+    );
+    const data = (payload as { data: Array<{ embedding: number[] }> }).data;
+
+    expect(data[0].embedding).toHaveLength(8);
+  });
+
+  it('falls back to the configured width when dimensions are absent', () => {
+    const { payload } = handle(JSON.stringify({ input: ['one'] }));
+    const data = (payload as { data: Array<{ embedding: number[] }> }).data;
+
+    expect(data[0].embedding).toHaveLength(DIMENSIONS);
+  });
+
+  it('accepts a bare string input', () => {
+    const { status, payload } = handle(JSON.stringify({ input: 'one' }));
+
+    expect(status).toBe(200);
+    expect((payload as { data: unknown[] }).data).toHaveLength(1);
+  });
+
+  it.each([
+    ['invalid JSON', '{'],
+    ['a missing input', '{}'],
+    ['a non-string array', JSON.stringify({ input: [1, 2] })],
+    ['zero dimensions', JSON.stringify({ input: ['a'], dimensions: 0 })],
+  ])('rejects %s', (_label, body) => {
+    expect(handle(body).status).toBe(400);
+  });
+});

--- a/scripts/offline-embedding-server.ts
+++ b/scripts/offline-embedding-server.ts
@@ -12,11 +12,15 @@
  * retrieval quality.
  */
 
-import { createServer } from 'node:http';
+import { createServer, type IncomingMessage } from 'node:http';
 import { logger } from 'logan-logger';
 import { EMBEDDING_DIMENSIONS } from '../src/lib/searchConfig';
 
 const DEFAULT_PORT = 8788;
+
+// Comfortably above any embedding width in use; the cap exists to bound the
+// allocation a request can ask for, not to describe a real model.
+const MAX_DIMENSIONS = 8192;
 
 /** FNV-1a. Chosen for being short and stable across runs, not for quality. */
 function hashToken(token: string): number {
@@ -34,10 +38,10 @@ export function embedText(text: string, dimensions: number): number[] {
 
   for (const token of tokens) {
     const hash = hashToken(token);
-    // The low bit picks a sign so that unrelated tokens can cancel rather than
-    // only ever accumulating, which keeps unrelated documents from drifting
-    // toward a single dense vector.
-    vector[hash % dimensions] += hash & 1 ? 1 : -1;
+    // The sign comes from the high bit because the bucket consumes the low
+    // ones: with a power-of-two width, a low-bit sign is fixed per bucket and
+    // every cosine stays positive, so unrelated documents never separate.
+    vector[hash % dimensions] += (hash >>> 31) & 1 ? 1 : -1;
   }
 
   const magnitude = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0));
@@ -91,8 +95,16 @@ export function createEmbeddingHandler(defaultDimensions: number) {
         ? body.dimensions
         : defaultDimensions;
 
-    if (dimensions < 1) {
-      return { status: 400, payload: { error: 'dimensions must be positive' } };
+    // Bounded before it reaches `new Array()`: an unbounded value either throws
+    // RangeError or allocates until the process dies, and this handler runs
+    // inside a request callback where either would take the service down.
+    if (dimensions < 1 || dimensions > MAX_DIMENSIONS) {
+      return {
+        status: 400,
+        payload: {
+          error: `dimensions must be between 1 and ${MAX_DIMENSIONS}`,
+        },
+      };
     }
 
     return {
@@ -113,7 +125,7 @@ export function createEmbeddingHandler(defaultDimensions: number) {
 }
 
 function readBody(
-  stream: NodeJS.ReadableStream,
+  stream: IncomingMessage,
   limitBytes: number,
 ): Promise<string | null> {
   return new Promise((resolve) => {
@@ -122,6 +134,9 @@ function readBody(
     stream.on('data', (chunk: Buffer) => {
       size += chunk.length;
       if (size > limitBytes) {
+        // Stop the sender rather than letting it keep uploading into a response
+        // that has already been ended.
+        stream.destroy();
         resolve(null);
         return;
       }
@@ -154,17 +169,27 @@ export function startOfflineEmbeddingServer(port: number) {
       return;
     }
 
-    void readBody(req, MAX_BODY_BYTES).then((rawBody) => {
-      if (rawBody === null) {
-        res.writeHead(413, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'request body too large' }));
-        return;
-      }
+    void readBody(req, MAX_BODY_BYTES)
+      .then((rawBody) => {
+        if (rawBody === null) {
+          res.writeHead(413, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'request body too large' }));
+          return;
+        }
 
-      const { status, payload } = handle(rawBody);
-      res.writeHead(status, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(payload));
-    });
+        const { status, payload } = handle(rawBody);
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      })
+      // Without this a throw here is an unhandled rejection that ends the
+      // process, surfacing much later as a connection error during indexing.
+      .catch((error: unknown) => {
+        logger.error('Offline embedding request failed', error);
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+        }
+        res.end(JSON.stringify({ error: 'internal error' }));
+      });
   });
 
   // Loopback only. This service authenticates nothing and must not be

--- a/scripts/offline-embedding-server.ts
+++ b/scripts/offline-embedding-server.ts
@@ -1,0 +1,187 @@
+/**
+ * Deterministic embedding service for CI and local development.
+ *
+ * Serves the OpenAI-compatible `/embeddings` contract so libsql-search's
+ * `openai-compatible` provider can index and query without credentials or a
+ * network. Vectors are a hashed bag of words: shared tokens raise cosine
+ * similarity, so search results are meaningful rather than arbitrary, and the
+ * same text always produces the same vector.
+ *
+ * Not a model. It has no semantics beyond token overlap, so it can verify that
+ * indexing, prerendering and search execute end to end, and nothing about
+ * retrieval quality.
+ */
+
+import { createServer } from 'node:http';
+import { logger } from 'logan-logger';
+import { EMBEDDING_DIMENSIONS } from '../src/lib/searchConfig';
+
+const DEFAULT_PORT = 8788;
+
+/** FNV-1a. Chosen for being short and stable across runs, not for quality. */
+function hashToken(token: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < token.length; i++) {
+    hash ^= token.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function embedText(text: string, dimensions: number): number[] {
+  const vector = new Array<number>(dimensions).fill(0);
+  const tokens = text.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+
+  for (const token of tokens) {
+    const hash = hashToken(token);
+    // The low bit picks a sign so that unrelated tokens can cancel rather than
+    // only ever accumulating, which keeps unrelated documents from drifting
+    // toward a single dense vector.
+    vector[hash % dimensions] += hash & 1 ? 1 : -1;
+  }
+
+  const magnitude = Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0));
+  if (magnitude === 0) {
+    // An empty or punctuation-only input still needs a unit vector, since the
+    // provider rejects a dimension mismatch and cosine distance needs a norm.
+    vector[0] = 1;
+    return vector;
+  }
+
+  return vector.map((v) => v / magnitude);
+}
+
+interface EmbeddingsRequestBody {
+  input?: unknown;
+  model?: unknown;
+  dimensions?: unknown;
+}
+
+function readInputTexts(body: EmbeddingsRequestBody): string[] | null {
+  const { input } = body;
+  if (typeof input === 'string') return [input];
+  if (Array.isArray(input) && input.every((v) => typeof v === 'string')) {
+    return input as string[];
+  }
+  return null;
+}
+
+export function createEmbeddingHandler(defaultDimensions: number) {
+  return function handle(rawBody: string): {
+    status: number;
+    payload: unknown;
+  } {
+    let body: EmbeddingsRequestBody;
+    try {
+      body = JSON.parse(rawBody) as EmbeddingsRequestBody;
+    } catch {
+      return { status: 400, payload: { error: 'invalid JSON body' } };
+    }
+
+    const texts = readInputTexts(body);
+    if (!texts) {
+      return {
+        status: 400,
+        payload: { error: 'input must be a string or an array of strings' },
+      };
+    }
+
+    const dimensions =
+      typeof body.dimensions === 'number' && Number.isInteger(body.dimensions)
+        ? body.dimensions
+        : defaultDimensions;
+
+    if (dimensions < 1) {
+      return { status: 400, payload: { error: 'dimensions must be positive' } };
+    }
+
+    return {
+      status: 200,
+      payload: {
+        object: 'list',
+        model: typeof body.model === 'string' ? body.model : 'offline-hash',
+        // The provider requires an index on every item and matches the
+        // response back to the request by it.
+        data: texts.map((text, index) => ({
+          object: 'embedding',
+          index,
+          embedding: embedText(text, dimensions),
+        })),
+      },
+    };
+  };
+}
+
+function readBody(
+  stream: NodeJS.ReadableStream,
+  limitBytes: number,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    stream.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > limitBytes) {
+        resolve(null);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    stream.on('error', () => resolve(null));
+  });
+}
+
+// Indexing sends whole article bodies in batches, so the cap is generous;
+// it exists only so a runaway request cannot exhaust memory.
+const MAX_BODY_BYTES = 32 * 1024 * 1024;
+
+export function startOfflineEmbeddingServer(port: number) {
+  const handle = createEmbeddingHandler(EMBEDDING_DIMENSIONS);
+
+  const server = createServer((req, res) => {
+    const path = new URL(req.url ?? '/', 'http://localhost').pathname;
+
+    if (req.method === 'GET' && path === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    if (req.method !== 'POST' || !path.endsWith('/embeddings')) {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+      return;
+    }
+
+    void readBody(req, MAX_BODY_BYTES).then((rawBody) => {
+      if (rawBody === null) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'request body too large' }));
+        return;
+      }
+
+      const { status, payload } = handle(rawBody);
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(payload));
+    });
+  });
+
+  // Loopback only. This service authenticates nothing and must not be
+  // reachable from outside the machine running it.
+  server.listen(port, '127.0.0.1', () => {
+    logger.info(
+      `Offline embedding service on http://127.0.0.1:${port}/v1 (${EMBEDDING_DIMENSIONS} dimensions)`,
+    );
+  });
+
+  return server;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const port = Number.parseInt(
+    process.env.OFFLINE_EMBEDDINGS_PORT ?? String(DEFAULT_PORT),
+    10,
+  );
+  startOfflineEmbeddingServer(Number.isInteger(port) ? port : DEFAULT_PORT);
+}

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -1,0 +1,170 @@
+/**
+ * Post-build smoke test.
+ *
+ * Boots the built server and exercises the paths the unit suite mocks around:
+ * prerendered article pages, the health check, and a real search request that
+ * embeds a query and reads vectors back out of the database. Its job is to fail
+ * when a dependency bump breaks rendering or search, which unit tests cannot
+ * see because they never run the built output.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { logger } from 'logan-logger';
+
+const PORT = Number.parseInt(process.env.SMOKE_PORT ?? '4331', 10);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+const SERVER_ENTRY = './dist/server/entry.mjs';
+const STARTUP_TIMEOUT_MS = 30_000;
+
+const failures: string[] = [];
+
+function check(name: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    logger.info(`ok   ${name}`);
+    return;
+  }
+  const message = detail ? `${name} — ${detail}` : name;
+  logger.error(`FAIL ${message}`);
+  failures.push(message);
+}
+
+function checkPrerenderedPages(): void {
+  const pages = [
+    'dist/client/index.html',
+    'dist/client/content/getting-started/welcome/index.html',
+    'dist/client/content/features/semantic-search/index.html',
+    'dist/client/content/theme/overview/index.html',
+  ];
+
+  for (const page of pages) {
+    const path = resolve(process.cwd(), page);
+    if (!existsSync(path)) {
+      check(`prerendered ${page}`, false, 'file not emitted');
+      continue;
+    }
+
+    const html = readFileSync(path, 'utf8');
+    // An article page built against an empty table still emits valid HTML, so
+    // presence of the file proves nothing on its own.
+    check(
+      `prerendered ${page}`,
+      html.includes('<article') || html.includes('<main'),
+      'no article or main element in output',
+    );
+  }
+}
+
+async function waitForServer(signal: AbortSignal): Promise<boolean> {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (signal.aborted) return false;
+    try {
+      const response = await fetch(`${BASE_URL}/api/health.json`);
+      if (response.status === 200 || response.status === 503) return true;
+    } catch {
+      // Server not listening yet.
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return false;
+}
+
+async function checkHealth(): Promise<void> {
+  const response = await fetch(`${BASE_URL}/api/health.json`);
+  const body = (await response.json()) as {
+    status?: string;
+    checks?: { database?: boolean; embeddings?: boolean };
+  };
+
+  check(
+    'GET /api/health.json reports ok',
+    response.status === 200 && body.status === 'ok',
+    `status ${response.status}, body ${JSON.stringify(body)}`,
+  );
+}
+
+async function checkSearch(): Promise<void> {
+  // Presence, not rank. Under the offline provider the vectors carry no
+  // semantics, so ordering is not a property worth asserting; that the indexed
+  // article comes back at all is what proves the round trip.
+  const query = 'semantic search embeddings';
+  const expectedSlug = 'features/semantic-search';
+  const response = await fetch(`${BASE_URL}/api/search.json`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, limit: 5 }),
+  });
+
+  if (response.status !== 200) {
+    const text = await response.text();
+    check(
+      'POST /api/search.json returns 200',
+      false,
+      `status ${response.status}: ${text.slice(0, 300)}`,
+    );
+    return;
+  }
+
+  const body = (await response.json()) as {
+    results?: Array<{ slug?: string; title?: string }>;
+  };
+  const results = body.results ?? [];
+
+  check('POST /api/search.json returns results', results.length > 0, 'empty');
+  check(
+    'search results carry a slug and title',
+    results.every((r) => Boolean(r.slug) && Boolean(r.title)),
+    JSON.stringify(results.slice(0, 2)),
+  );
+  check(
+    `search finds ${expectedSlug}`,
+    results.some((r) => r.slug === expectedSlug),
+    `got ${JSON.stringify(results.map((r) => r.slug))}`,
+  );
+}
+
+async function main(): Promise<void> {
+  checkPrerenderedPages();
+
+  if (!existsSync(resolve(process.cwd(), SERVER_ENTRY))) {
+    check(`${SERVER_ENTRY} exists`, false, 'run pnpm build first');
+    process.exit(1);
+  }
+
+  const server = spawn('node', [SERVER_ENTRY], {
+    env: { ...process.env, PORT: String(PORT), HOST: '127.0.0.1' },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+
+  const exited = new AbortController();
+  server.on('exit', (code) => {
+    if (code !== 0 && code !== null) {
+      logger.error(`Server exited early with code ${code}`);
+    }
+    exited.abort();
+  });
+
+  try {
+    if (!(await waitForServer(exited.signal))) {
+      check('server responds on /api/health.json', false, 'startup timed out');
+      return;
+    }
+
+    await checkHealth();
+    await checkSearch();
+  } finally {
+    server.kill('SIGTERM');
+  }
+}
+
+await main();
+
+if (failures.length > 0) {
+  logger.error(`Smoke test failed: ${failures.length} check(s)`);
+  process.exit(1);
+}
+
+logger.info('Smoke test passed');
+process.exit(0);

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -88,13 +88,15 @@ async function checkHealth(): Promise<void> {
 async function checkSearch(): Promise<void> {
   // Presence, not rank. Under the offline provider the vectors carry no
   // semantics, so ordering is not a property worth asserting; that the indexed
-  // article comes back at all is what proves the round trip.
+  // article comes back at all is what proves the round trip. The limit is the
+  // API maximum so the check does not quietly become a rank assertion, and so a
+  // coin flip, once the corpus grows past a handful of articles.
   const query = 'semantic search embeddings';
   const expectedSlug = 'features/semantic-search';
   const response = await fetch(`${BASE_URL}/api/search.json`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ query, limit: 5 }),
+    body: JSON.stringify({ query, limit: 20 }),
   });
 
   if (response.status !== 200) {
@@ -143,6 +145,11 @@ async function main(): Promise<void> {
     if (code !== 0 && code !== null) {
       logger.error(`Server exited early with code ${code}`);
     }
+    exited.abort();
+  });
+  // An unhandled 'error' event throws instead of producing a FAIL line.
+  server.on('error', (error) => {
+    check('server process starts', false, String(error));
     exited.abort();
   });
 

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -177,3 +177,41 @@ describe('hybridSearchEnabled', () => {
     },
   );
 });
+
+describe('embedding provider configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reports the offline base URL when set', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', 'http://127.0.0.1:8788/v1');
+
+    expect(env.offlineEmbeddingsBaseUrl).toBe('http://127.0.0.1:8788/v1');
+    expect(env.hasEmbeddingProvider).toBe(true);
+  });
+
+  it('accepts Workers AI credentials alone', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', '');
+    vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', 'account');
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', 'token');
+
+    expect(env.hasEmbeddingProvider).toBe(true);
+  });
+
+  it('accepts the offline service without Cloudflare credentials', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', 'http://127.0.0.1:8788/v1');
+    vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', '');
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', '');
+
+    expect(env.hasCloudflareCredentials).toBe(false);
+    expect(env.hasEmbeddingProvider).toBe(true);
+  });
+
+  it('reports no provider when neither is configured', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', '');
+    vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', '');
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', '');
+
+    expect(env.hasEmbeddingProvider).toBe(false);
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -94,6 +94,22 @@ export const env = {
     );
   },
 
+  /**
+   * Base URL of an OpenAI-compatible embedding service, used instead of
+   * Workers AI when set. Exists so CI and forks can index and search without
+   * credentials; production leaves it unset.
+   */
+  get offlineEmbeddingsBaseUrl(): string | undefined {
+    return getEnv('OFFLINE_EMBEDDINGS_BASE_URL');
+  },
+
+  /** Whether either embedding provider is configured. */
+  get hasEmbeddingProvider(): boolean {
+    return (
+      Boolean(this.offlineEmbeddingsBaseUrl) || this.hasCloudflareCredentials
+    );
+  },
+
   /** Proxy header explicitly trusted for rate-limit client identity */
   get rateLimitTrustedProxyHeader(): RateLimitTrustedProxyHeader | undefined {
     const value = getEnv('RATE_LIMIT_TRUSTED_PROXY_HEADER');

--- a/src/lib/searchConfig.test.ts
+++ b/src/lib/searchConfig.test.ts
@@ -55,3 +55,66 @@ describe('searchConfig', () => {
     },
   );
 });
+
+describe('offline embedding provider', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('replaces Workers AI when a base URL is configured', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', 'http://127.0.0.1:8788/v1');
+
+    expect(getEmbeddingOptions()).toEqual({
+      provider: 'openai-compatible',
+      baseUrl: 'http://127.0.0.1:8788/v1',
+      model: 'offline-hash',
+      dimensions: EMBEDDING_DIMENSIONS,
+    });
+  });
+
+  it('needs no Cloudflare credentials', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', 'http://127.0.0.1:8788/v1');
+    vi.stubEnv('CLOUDFLARE_ACCOUNT_ID', '');
+    vi.stubEnv('CLOUDFLARE_API_TOKEN', '');
+
+    expect(() => getEmbeddingOptions()).not.toThrow();
+  });
+
+  it('carries overrides through', () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', 'http://127.0.0.1:8788/v1');
+    const controller = new AbortController();
+
+    const options = getEmbeddingOptions({
+      timeoutMs: 99,
+      signal: controller.signal,
+    });
+
+    expect(options.timeoutMs).toBe(99);
+    expect(options.signal).toBe(controller.signal);
+  });
+
+  // Two embedding spaces must never share a table: the vectors are not
+  // comparable, and nothing at query time would report the mismatch.
+  it('indexes into its own table', async () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', 'http://127.0.0.1:8788/v1');
+    vi.resetModules();
+    const offline = await import('./searchConfig');
+
+    expect(offline.IS_OFFLINE_EMBEDDINGS).toBe(true);
+    expect(offline.SEARCH_TABLE_NAME).not.toBe(SEARCH_TABLE_NAME);
+    expect(offline.SEARCH_TABLE_NAME).toContain(String(EMBEDDING_DIMENSIONS));
+    expect(offline.SEARCH_FTS_TABLE_NAME).toBe(
+      `${offline.SEARCH_TABLE_NAME}_fts`,
+    );
+  });
+
+  it('uses the Workers AI table when unset', async () => {
+    vi.stubEnv('OFFLINE_EMBEDDINGS_BASE_URL', '');
+    vi.resetModules();
+    const online = await import('./searchConfig');
+
+    expect(online.IS_OFFLINE_EMBEDDINGS).toBe(false);
+    expect(online.SEARCH_TABLE_NAME).toBe('articles_cf_bgem3_1024');
+  });
+});

--- a/src/lib/searchConfig.ts
+++ b/src/lib/searchConfig.ts
@@ -1,7 +1,16 @@
 import type { EmbeddingOptions } from '@logan/libsql-search';
-import { getRequiredEnv } from './env';
+import { env, getRequiredEnv } from './env';
 
-export const SEARCH_TABLE_NAME = 'articles_cf_bgem3_1024';
+// Deterministic local embeddings, so CI and fork PRs can index, prerender and
+// search without credentials. Its vectors are a different embedding space from
+// Workers AI, so it gets its own table rather than sharing one.
+const OFFLINE_MODEL = 'offline-hash';
+
+export const IS_OFFLINE_EMBEDDINGS = Boolean(env.offlineEmbeddingsBaseUrl);
+
+export const SEARCH_TABLE_NAME = IS_OFFLINE_EMBEDDINGS
+  ? 'articles_offline_hash_1024'
+  : 'articles_cf_bgem3_1024';
 
 // FTS5 index over the same rows, joined back by rowid = articles.id.
 export const SEARCH_FTS_TABLE_NAME = `${SEARCH_TABLE_NAME}_fts`;
@@ -29,7 +38,8 @@ export const FUSION_WEIGHTS = {
 } as const;
 
 // Fixed by @cf/baai/bge-m3, the only model Workers AI exposes through this
-// adapter. The table's F32_BLOB width must equal it exactly.
+// adapter. The table's F32_BLOB width must equal it exactly. The offline
+// provider matches it so both paths exercise the same schema.
 export const EMBEDDING_DIMENSIONS = 1024;
 
 // Query-time embedding is now a network call on the request path. The library
@@ -37,13 +47,24 @@ export const EMBEDDING_DIMENSIONS = 1024;
 export const SEARCH_EMBEDDING_TIMEOUT_MS = 5000;
 
 /**
- * Cloudflare Workers AI credentials for indexing and query-time embedding.
- * Throws rather than returning a partial config, so a missing credential
- * surfaces at the call site instead of as an opaque upstream 4xx.
+ * Embedding provider for indexing and query-time embedding. Throws rather than
+ * returning a partial config, so a missing credential surfaces at the call site
+ * instead of as an opaque upstream 4xx.
  */
 export function getEmbeddingOptions(
   overrides?: Pick<EmbeddingOptions, 'timeoutMs' | 'signal'>,
 ): EmbeddingOptions {
+  const offlineBaseUrl = env.offlineEmbeddingsBaseUrl;
+  if (offlineBaseUrl) {
+    return {
+      provider: 'openai-compatible',
+      baseUrl: offlineBaseUrl,
+      model: OFFLINE_MODEL,
+      dimensions: EMBEDDING_DIMENSIONS,
+      ...overrides,
+    };
+  }
+
   return {
     provider: 'cloudflare',
     accountId: getRequiredEnv('CLOUDFLARE_ACCOUNT_ID'),

--- a/src/pages/api/health.json.ts
+++ b/src/pages/api/health.json.ts
@@ -38,7 +38,7 @@ async function isDatabaseReady(): Promise<boolean> {
 
 export const GET: APIRoute = async () => {
   const database = await isDatabaseReady();
-  const embeddings = env.hasCloudflareCredentials;
+  const embeddings = env.hasEmbeddingProvider;
   const healthy = database && embeddings;
 
   return new Response(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
+    setupFiles: ['./vitest.setup.ts'],
     globals: true,
     server: {
       deps: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,5 @@
+// The offline embedding service switches both provider and table name, and the
+// table name is resolved at module load. An ambient value from a shell or a CI
+// job would flip the suite onto that branch before any test could stub it, so
+// it is cleared here; tests that want it use vi.stubEnv.
+delete process.env.OFFLINE_EMBEDDINGS_BASE_URL;


### PR DESCRIPTION
## Summary
- CI now always indexes content, builds, and smoke-tests with no secrets present, closing the coverage gap that left fork and Dependabot PRs — most of this repo's PR volume — building against an empty search table
- Adds a dependency-free offline embedding service and a smoke test that exercises the built server end to end

## Problem

Since embeddings moved to Workers AI, `pnpm index:local` needs secrets that fork and Dependabot PRs never receive. CI's `HAS_WORKERS_AI` gate skipped indexing and built against an empty table, so `getStaticPaths`, `[...slug].astro`, the sidebar, markdown rendering and the search route were never executed. Dependabot is most of this repo's PR volume.

## Change

Adds `scripts/offline-embedding-server.ts`, a dependency-free deterministic service implementing the OpenAI-compatible `/embeddings` contract that libsql-search's `openai-compatible` provider expects (response items require an `index`, embedding length must match `dimensions`, redirects are rejected). `OFFLINE_EMBEDDINGS_BASE_URL` selects it over Workers AI for indexing and query-time embedding. Vectors are a hashed bag of words in a different embedding space, so they get their own table, `articles_offline_hash_1024`; the width stays 1024 so both paths exercise the same schema. Adds `scripts/smoke-test.ts`, which boots the built server and asserts prerendered pages, health, and a search response containing the indexed article. CI always indexes, builds and smoke-tests with no secrets; the `HAS_WORKERS_AI` gate and its secret references are gone.

## Verification

The full credential-free sequence prerenders 4 pages, health reports ok, search returns results. Negative control: with the rows deleted, search 500s and the smoke test exits non-zero, so it genuinely catches the empty-table regression rather than passing vacuously. 380 tests pass both with and without `OFFLINE_EMBEDDINGS_BASE_URL` in the environment. Lint and `tsc --noEmit` clean.

## Not a model

The offline vectors have no semantics beyond token overlap. On sample queries the expected article is not always ranked first, so the smoke test asserts presence rather than rank. Search quality can only be judged against Workers AI.

## Security

The workflow triggers on `pull_request`, not `pull_request_target`, so fork PRs never had secret access; this removes the last use of `CLOUDFLARE_*` from the test job. No fork PR can reach an external service — the provider points at a `127.0.0.1` base URL with no fallback to Cloudflare.

Closes #108