### PR TITLE
chore: drop AGENTS.md and GEMINI.md ignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,8 @@ local.db-wal
 .gemini
 .agent
 
-# Agent instructions, local-only (AGENTS.md and GEMINI.md symlink to CLAUDE.md)
+# Agent instructions, local-only
 CLAUDE.md
-AGENTS.md
-GEMINI.md
 
 # Internal working documents
 _/


### PR DESCRIPTION
These paths were symlinks to CLAUDE.md and no longer exist, so the .gitignore entries ignored nothing and the adjacent comment described a layout the repo had moved past. CLAUDE.md stays ignored.